### PR TITLE
API: Specify param as long as it is not None

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -73,7 +73,7 @@ class SynapseAdmin:
         """ Set the user password, and logs the user out if requested
         """
         data = {"new_password": password}
-        if no_logout:
+        if no_logout is not None:
             data.update({"logout_devices": no_logout})
         return self.query("post", f"v1/reset_password/{user_id}", data=data)
 


### PR DESCRIPTION
I have noticed this in other params too. I'm not sure if it is a bug, so I'm making this test PR.