### PR TITLE
Implement command for user whois

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ python3 setup.py install
   * [x] `user deactivate <user id>`
   * [x] `user password <user id>`
   * [x] `user membership <user id>`
+  * [x] `user whois <user id>`
   * [ ] `user shadow_ban <user id>`
   * [ ] Additional commands and aliases derived from user API's
       * [x] `user search <search-term>` (shortcut to `user list -d -g -n <search-term>`)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -129,6 +129,11 @@ class SynapseAdmin:
             data.update({"deactivated": False})
         return self.query("put", f"v2/users/{user_id}", data=data)
 
+    def user_whois(self, user_id):
+        """ Return information about the active sessions for a specific user
+        """
+        return self.query("get", f"v1/whois/{user_id}")
+
     def room_list(self, _from, limit, name, order_by, reverse):
         """ List and search rooms
         """

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -306,3 +306,12 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
             helper.output(modified)
     else:
         click.echo("Abort.")
+
+@user.command()
+@click.argument("user_id", type=str)
+@click.pass_obj
+def whois(helper, user_id):
+    """ Return information about the active sessions for a specific user
+    """
+    user_data = helper.api.user_whois(user_id)
+    helper.output(user_data)


### PR DESCRIPTION
I was testing a Synapse admin web UI (https://github.com/Awesome-Technologies/synapse-admin
) when I found that I could see all the sessions of a user (including the IP address they used when logging in). This cheat-like feature sounds useful, and so I made this PR.

Not sure if I should add "including IP addresses information" in the docstring.