### PR TITLE
README: Say that `user deactivate` also has GDPR erase option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ python3 setup.py install
   * [x] `user details <user id>`
   * [x] `user modify <user id>` (also used for user creation)
   * [x] `user list`
-  * [x] `user deactivate <user id>`
+  * [x] `user deactivate <user id>` (including GDPR erase)
   * [x] `user password <user id>`
   * [x] `user membership <user id>`
   * [x] `user whois <user id>`


### PR DESCRIPTION
In this web UI (https://github.com/Awesome-Technologies/synapse-admin), in one of the screenshot, there is an option to erase user data (for GDPR). I thought synadm doesn't have this feature yet until I grepped the codebase and found that it exists. This feature should be told to the user at the top level documentation.