### PR TITLE
Activating a user without setting a password is a valid user case

### DIFF
--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -277,10 +277,6 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
     if password_prompt and password:
         click.echo("Use either '-p' or '-P secret', not both.")
         raise SystemExit(1)
-    if deactivation == "activate" and not (password_prompt or password):
-        click.echo("Need to set password when activating a user.")
-        click.echo("Add either '-p' or '-P secret' to your command.")
-        raise SystemExit(1)
     if deactivation == "deactivate" and (password_prompt or password):
         click.echo(
             "Deactivating a user and setting a password doesn't make sense.")


### PR DESCRIPTION
Activating users in an SSO environment is a valid operation even when not providing a password. We shouldn't require a password to be set in those cases.