### PR TITLE
Implements room_alias resolution to room_id

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -32,6 +32,7 @@ import requests
 from http.client import HTTPConnection
 import datetime
 import json
+import urllib.parse
 
 
 class ApiRequest:
@@ -206,6 +207,11 @@ class Matrix(ApiRequest):
             "user": f"{user_id}",
             "initial_device_display_name": "synadm matrix login command"
         })
+
+    def resolve(self, room_alias):
+        """ Allow a user to get the room_id with a given room_alias
+        """
+        return self.query("get", f"client/r0/directory/room/{urllib.parse.quote(room_alias)}")
 
     def raw_request(self, endpoint, method, data, token=None):
         data_dict = {}

--- a/synadm/cli/room.py
+++ b/synadm/cli/room.py
@@ -40,6 +40,16 @@ def join(helper, room_id_or_alias, user_id):
     helper.output(out)
 
 
+@room.command()
+@click.argument("room_alias", type=str)
+@click.pass_obj
+def resolve(helper, room_alias):
+    """ lookup room id from alias
+    """
+    out = helper.matrix_api.resolve(room_alias)
+    helper.output(out)
+
+
 @room.command(name="list")
 @click.pass_obj
 @click.option(


### PR DESCRIPTION
When you need to get the `room_id` from a known `room_alias` you can now use `room resolve <room_alias>`. This is handy when one also uses other tools besides `synadm` that may only use a `room_id` and cannot operate with a `room_alias`.

Example:

```
synadm room resolve "#foo:matrix.org"

-------  ------------------------------
room_id  !jLHcnCpckBMWIfzTOa:matrix.org
servers  ['matrix.org']
-------  ------------------------------
```