### PR TITLE
Remove trailing slash from media API calls

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -725,7 +725,7 @@ class SynapseAdmin(ApiRequest):
         """ Quarantine a single piece of local or remote media
         """
         return self.query(
-            "post", f"v1/media/quarantine/{server_name}/{media_id}/", data={}
+            "post", f"v1/media/quarantine/{server_name}/{media_id}", data={}
         )
 
     def room_media_quarantine(self, room_id):
@@ -821,7 +821,7 @@ class SynapseAdmin(ApiRequest):
         from being quarantined
         """
         return self.query(
-            "post", f"v1/media/protect/{media_id}/", data={}
+            "post", f"v1/media/protect/{media_id}", data={}
         )
 
     def purge_media_cache(self, before_days, before, _before_ts):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -769,7 +769,7 @@ class SynapseAdmin(ApiRequest):
         """ Delete a specific (local) media_id
         """
         return self.query(
-            "delete", f"v1/media/{server_name}/{media_id}/", data={}
+            "delete", f"v1/media/{server_name}/{media_id}", data={}
         )
 
     def media_delete_by_date_or_size(self, server_name, before_days, before,


### PR DESCRIPTION
This fixes the issue I've described at https://matrix.to/#/!mLATeUxylgHiofUzHJ:peek-a-boo.at/$uxyw6W9u-nepUREGUFnWT2tsJ42hC90uT2B__IvaU3U?via=peek-a-boo.at&via=matrix.org&via=matrix.forster.cc where deleting media with given ID fails with Unrecognized request error.