### PR TITLE
Adjusted human output of shadow-ban command

### DIFF
--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -578,10 +578,13 @@ def user_shadow_ban(helper, user_id, unban):
         click.echo("Failed to shadow-ban: {}".format(user_id))
         raise SystemExit(1)
     if helper.output_format == "human":
+        action = "shadow-ban"
+        if unban:
+            action = "shadow-unban"
         if user_ban:
-            click.echo("Failed to shadow-ban the user: {}".format(user_id))
+            click.echo("Failed to {} the user: {}".format(action, user_id))
             helper.output(user_ban)
         else:
-            click.echo("Successfully shadow-banned user: {}".format(user_id))
+            click.echo("Successfully {}ned user: {}".format(action, user_id))
     else:
         helper.output(user_ban)


### PR DESCRIPTION
Fixed an issue where the human output of the `shadow-ban` command would not distinguish between '_ban_' and the '_unban_'. Now the human output is adjusted based on the selected option