### PR TITLE
Added support for localpart as <user_id> argument

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -304,15 +304,11 @@ class Matrix(ApiRequest):
         """
         if user_id is None:
             return None
-        elif any(x in user_id for x in ["@", ":"]):
-            if re.match(r"\@.+\:.+", user_id):
-                return user_id
-            else:
-                mxid = "@{}:{}".format(re.sub("[@:]", "", user_id),
-                                       self.server_name())
-                return mxid
+        elif re.match(r"@[\w\d\_\.\_\=\-\/]+:[\w\d]+", user_id):
+            return user_id
         else:
-            mxid = "@{}:{}".format(user_id, self.server_name())
+            localpart = re.sub("[@:]", "", user_id)
+            mxid = "@{}:{}".format(localpart, self.server_name())
             return mxid
 
 

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -299,7 +299,7 @@ class Matrix(ApiRequest):
             user_id (string): User ID given by user as command argument.
 
         Returns:
-            string: the fully qualified Matrix User ID (MXID) or None if the 
+            string: the fully qualified Matrix User ID (MXID) or None if the
                 user_id parameter is None.
         """
         if user_id is None:
@@ -308,8 +308,8 @@ class Matrix(ApiRequest):
             if re.match(r"\@.+\:.+", user_id):
                 return user_id
             else:
-                mxid = "@{}:{}".format(re.sub("[@:]", "", user_id), 
-                                    self.server_name())
+                mxid = "@{}:{}".format(re.sub("[@:]", "", user_id),
+                                       self.server_name())
                 return mxid
         else:
             mxid = "@{}:{}".format(user_id, self.server_name())

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -304,7 +304,7 @@ class Matrix(ApiRequest):
         """
         if user_id is None:
             return None
-        elif re.match(r"@[\w\d\_\.\_\=\-\/]+:[\w\d]+", user_id):
+        elif re.match(r"@[-_/=\w\d\.]+:[-_.\w\d]+", user_id):
             return user_id
         else:
             localpart = re.sub("[@:]", "", user_id)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -291,8 +291,9 @@ class Matrix(ApiRequest):
         return resp['server_name']
 
     def generate_mxid(self, user_id):
-        """ Checks if the given user ID is already a MXID else generating
-            the MXID from the plain user name and the server domain.
+        """ Checks whether the given user ID is an MXID already or else
+        generates it from the passed string and the homeserver name fetched
+        via the server_name method.
 
         Args:
             user_id (string): User ID given by user as command argument.
@@ -304,10 +305,14 @@ class Matrix(ApiRequest):
         if user_id is None:
             return None
         elif any(x in user_id for x in ["@", ":"]):
-            return user_id
+            if re.match(r"\@.+\:.+", user_id):
+                return user_id
+            else:
+                mxid = "@{}:{}".format(re.sub("[@:]", "", user_id), 
+                                    self.server_name())
+                return mxid
         else:
-            mxid = "@{}:{}".format(re.sub("@|:", "", user_id), 
-                                   self.server_name())
+            mxid = "@{}:{}".format(user_id, self.server_name())
             return mxid
 
 

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -304,7 +304,7 @@ class Matrix(ApiRequest):
         """
         if user_id is None:
             return None
-        elif re.match(r"@[-_./=\w\d]+:[-.\w\d]+", user_id):
+        elif re.match(r"@[-./=\w]+:[-.\w]+", user_id):
             return user_id
         else:
             localpart = re.sub("[@:]", "", user_id)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -34,6 +34,7 @@ import datetime
 import json
 import urllib.parse
 import time
+import re
 
 
 class ApiRequest:
@@ -288,6 +289,26 @@ class Matrix(ApiRequest):
             self.log.error("Local server name could not be fetched.")
             return None
         return resp['server_name']
+
+    def generate_mxid(self, user_id):
+        """ Checks if the given user ID is already a MXID else generating
+            the MXID from the plain user name and the server domain.
+
+        Args:
+            user_id (string): User ID given by user as command argument.
+
+        Returns:
+            string: the fully qualified Matrix User ID (MXID) or None if the 
+                user_id parameter is None.
+        """
+        if user_id is None:
+            return None
+        elif any(x in user_id for x in ["@", ":"]):
+            return user_id
+        else:
+            mxid = "@{}:{}".format(re.sub("@|:", "", user_id), 
+                                   self.server_name())
+            return mxid
 
 
 class SynapseAdmin(ApiRequest):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -304,7 +304,7 @@ class Matrix(ApiRequest):
         """
         if user_id is None:
             return None
-        elif re.match(r"@[-_/=\w\d\.]+:[.-\w\d]+", user_id):
+        elif re.match(r"@[-_./=\w\d]+:[-.\w\d]+", user_id):
             return user_id
         else:
             localpart = re.sub("[@:]", "", user_id)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -304,7 +304,7 @@ class Matrix(ApiRequest):
         """
         if user_id is None:
             return None
-        elif re.match(r"@[-_/=\w\d\.]+:[-_.\w\d]+", user_id):
+        elif re.match(r"@[-_/=\w\d\.]+:[.-\w\d]+", user_id):
             return user_id
         else:
             localpart = re.sub("[@:]", "", user_id)

--- a/synadm/cli/matrix.py
+++ b/synadm/cli/matrix.py
@@ -56,7 +56,8 @@ def login_cmd(helper, user_id, password):
         else:
             password = click.prompt("Password", hide_input=True)
 
-    login = helper.matrix_api.user_login(user_id, password)
+    mxid = helper.matrix_api.generate_mxid(user_id)
+    login = helper.matrix_api.user_login(mxid, password)
 
     if helper.batch:
         if login is None:

--- a/synadm/cli/media.py
+++ b/synadm/cli/media.py
@@ -85,9 +85,10 @@ def media_list_cmd(ctx, helper, room_id, user_id, from_, limit, sort, reverse,
         helper.output(media_list)
     elif user_id:
         from synadm.cli import user
+        mxid = helper.matrix_api.generate_mxid(user_id)
         ctx.invoke(
             user.get_function("user_media_cmd"),
-            user_id=user_id, from_=from_, limit=limit, sort=sort,
+            user_id=mxid, from_=from_, limit=limit, sort=sort,
             reverse=reverse, datetime=datetime
         )
 
@@ -131,7 +132,8 @@ def media_quarantine_cmd(helper, server_name, media_id, user_id, room_id):
     elif room_id:
         media_quarantined = helper.api.room_media_quarantine(room_id)
     elif user_id:
-        media_quarantined = helper.api.user_media_quarantine(user_id)
+        mxid = helper.matrix_api.generate_mxid(user_id)
+        media_quarantined = helper.api.user_media_quarantine(mxid)
 
     if media_quarantined is None:
         click.echo("Media could not be quarantined.")

--- a/synadm/cli/room.py
+++ b/synadm/cli/room.py
@@ -36,7 +36,8 @@ def room():
 def join(helper, room_id_or_alias, user_id):
     """ Join a room
     """
-    out = helper.api.room_join(room_id_or_alias, user_id)
+    mxid = helper.matrix_api.generate_mxid(user_id)
+    out = helper.api.room_join(room_id_or_alias, mxid)
     helper.output(out)
 
 
@@ -253,8 +254,9 @@ def delete(ctx, helper, room_id, new_room_user_id, room_name, message, block,
                      type=bool, default=False, show_default=False)
     )
     if sure:
+        mxid = helper.matrix_api.generate_mxid(new_room_user_id)
         room_del = helper.api.room_delete(
-            room_id, new_room_user_id, room_name,
+            room_id, mxid, room_name,
             message, block, no_purge)
         if room_del is None:
             click.echo("Room not deleted.")
@@ -305,5 +307,6 @@ def make_admin(helper, room_id, user_id):
     the user.
     """
 
-    out = helper.api.room_make_admin(room_id, user_id)
+    mxid = helper.matrix_api.generate_mxid(user_id)
+    out = helper.api.room_make_admin(room_id, mxid)
     helper.output(out)


### PR DESCRIPTION
Users can now enter the localpart as `<user_id>` argument instead of providing the full MXID
