### PR TITLE
cli: fall back to str() instead of silence for human output

### DIFF
--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -44,7 +44,7 @@ def humanize(data):
         return "\n".join(data)
     if isinstance(data, dict):
         return tabulate.tabulate(data.items(), tablefmt="plain")
-    return None
+    return str(data)
 
 
 class APIHelper:


### PR DESCRIPTION
When the output consists only of a single value (such as the result of "synadm room resolve"), humanize() returned None, causing nothing at all to be printed.