### PR TITLE
Fix NoneType err in server_name method

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -285,7 +285,7 @@ class Matrix(ApiRequest):
                 could not fetch it for any reason.
         """
         resp = self.query("get", "key/v2/server")
-        if "server_name" not in resp:
+        if not resp or not resp.get("server_name"):
             self.log.error("Local server name could not be fetched.")
             return None
         return resp['server_name']


### PR DESCRIPTION
- If fetching of key/v2/server doesn't get a response at all (api.query
  returned None already) fail and log immediately instead of trying to look
  into a dict.
- Try to look into the dict in a second step (or).