### PR TITLE
Auto-retrieve or use a pre-configured homeserver name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 pyyaml
 tabulate
 click-option-group>=0.5.2
+dnspython

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         "tabulate",
         "PyYaml",
         "click-option-group>=0.5.2",
+        "dnspython"
     ],
     entry_points="""
         [console_scripts]

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -209,15 +209,15 @@ class MiscRequest(ApiRequest):
             timeout, debug
         )
 
-    def server_name_well_known(self, base_url):
-        """Retrieve the Matrix server's name and Server-Server API port via its
-        .well-known resource.
+    def federation_uri_well_known(self, base_url):
+        """Retrieve the URI to the Server-Server (Federation) API port via the
+        .well-known resource of a Matrix server/domain.
 
         Args:
             base_url: proto://name or proto://fqdn
 
         Returns:
-            string: proto://fqdn:port of the delegated server for server-server
+            string: proto://fqdn:port of the delegated server for Server-Server
                 communication between Matrix homeservers or None on errors.
         """
         resp = self.query(
@@ -227,9 +227,9 @@ class MiscRequest(ApiRequest):
         )
         if resp is not None:
             if ":" in resp["m.server"]:
-                return resp["m.server"]
+                return "https://" + resp["m.server"]
             else:
-                return resp["m.server"] + ":8448"
+                return "https://" + resp["m.server"] + ":8448"
         self.log.error(".well-known/matrix/server could not be fetched.")
         return None
 

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -242,7 +242,7 @@ class Matrix(ApiRequest):
             methods for requesting REST API's
     """
     def __init__(self, log, user, token, base_url, matrix_path,
-                 timeout, debug, server_discovery, hostname):
+                 timeout, debug):
         """Initialize the Matrix API object
 
         Args:
@@ -264,8 +264,6 @@ class Matrix(ApiRequest):
             timeout, debug
         )
         self.user = user
-        self.server_discovery = server_discovery
-        self.hostname = hostname
 
     def user_login(self, user_id, password):
         """Login as a Matrix user and retrieve an access token

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -218,7 +218,7 @@ class MiscRequest(ApiRequest):
             base_url: proto://name or proto://fqdn
 
         Returns:
-            string: proto://fqdn:port of the delegated server for Server-Server
+            string: https://fqdn:port of the delegated server for Server-Server
                 communication between Matrix homeservers or None on errors.
         """
         resp = self.query(

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -73,7 +73,8 @@ class ApiRequest:
         if debug:
             HTTPConnection.debuglevel = 1
 
-    def query(self, method, urlpart, params=None, data=None, token=None, base_url_override=None):
+    def query(self, method, urlpart, params=None, data=None, token=None,
+              base_url_override=None, verify=True):
         """Generic wrapper around requests methods.
 
         Handles requests methods, logging and exceptions.
@@ -108,7 +109,7 @@ class ApiRequest:
         try:
             resp = getattr(requests, method)(
                 url, headers=self.headers, timeout=self.timeout,
-                params=params, json=data
+                params=params, json=data, verify=verify
             )
             if not resp.ok:
                 self.log.warning(f"Synapse returned status code "
@@ -210,7 +211,11 @@ class MiscRequest(ApiRequest):
     def server_name_well_known(self):
         """Receive the Matrix server's name via it's .well-known resource.
         """
-        resp = self.query("get", ".well-known/matrix/server", base_url_override="https://localhost")
+        resp = self.query(
+            "get", ".well-known/matrix/server",
+            base_url_override="https://localhost",
+            verify=False
+        )
         if resp is not None:
             server = resp["m.server"].split(":")[0]
             return server

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -97,8 +97,10 @@ class ApiRequest:
         if base_url_override:
             self.log.debug("base_url override!")
             url = f"{base_url_override}/{self.path}/{urlpart}"
+            host_descr = urllib.parse.urlparse(base_url_override).netloc
         else:
             url = f"{self.base_url}/{self.path}/{urlpart}"
+            host_descr = "Synapse"
         self.log.info("Querying %s on %s", method, url)
 
         if token:
@@ -111,12 +113,12 @@ class ApiRequest:
                 params=params, json=data, verify=verify
             )
             if not resp.ok:
-                self.log.warning(f"Synapse returned status code "
+                self.log.warning(f"{host_descr} returned status code "
                                  f"{resp.status_code}")
             return resp.json()
         except Exception as error:
-            self.log.error("%s while querying Synapse: %s",
-                           type(error).__name__, error)
+            self.log.error("%s while querying %s: %s",
+                           type(error).__name__, host_descr, error)
         return None
 
     def _timestamp_from_days_ago(self, days):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -82,6 +82,10 @@ class ApiRequest:
                 to None.
             data (dict, optional): Request body used in POST, PUT, DELETE
                 requests.  Defaults to None.
+            base_url_override (bool): The default setting of self.base_url set
+                on initialization can be overwritten using this argument.
+            verify(bool): Mandatory SSL verification is turned on by default and
+                can be turned off using this method.
 
         Returns:
             string or None: Usually a JSON string containing

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -218,7 +218,6 @@ class MiscRequest(ApiRequest):
         resp = self.query(
             "get", ".well-known/matrix/server",
             base_url_override=base_url,
-            verify=False
         )
         if resp is not None:
             if ":" in resp["m.server"]:

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -233,45 +233,6 @@ class MiscRequest(ApiRequest):
         self.log.error(".well-known/matrix/server could not be fetched.")
         return None
 
-    def server_name_keys_api(self, server_server_uri):
-        """Retrieve the Matrix server's own homeserver name via the
-        Server-Server (Federation) API.
-
-        Args:
-            server_server_uri (string): proto://name:port or proto://fqdn:port
-
-        Returns:
-            string: The Matrix server's homeserver name or FQDN, usually
-            something like matrix.DOMAIN or DOMAIN
-        """
-        resp = self.query("get", "key/v2/server",
-            base_url_override=server_server_uri
-        )
-        if not resp or not resp.get("server_name"):
-            self.log.error("The homeserver name could not be fetched via the "
-                           "federation API key/v2/server.")
-            return None
-        return resp['server_name']
-
-    def retrieve_homeserver_name(self, uri):
-        """Try to retrieve the homeserver name via .well-known and a
-        Server-Server (Federation) API.
-
-        FIXME: Fall back to a statically configured name in config.yaml or
-        rather use the configured name if present and just don't try to
-        fetch.
-
-        Args:
-            uri (string): proto://name:port or proto://fqdn:port
-
-        Returns:
-            string: hostname, FQDN or DOMAIN; or None on errors.
-        """
-        federation_uri = self.server_name_well_known(uri)
-        if not federation_uri:
-            return None
-        return self.server_name_keys_api(federation_uri)
-
 
 class Matrix(ApiRequest):
     """ Matrix API client
@@ -425,6 +386,26 @@ class Matrix(ApiRequest):
             localpart = re.sub("[@:]", "", user_id)
             mxid = "@{}:{}".format(localpart, self.server_name())
             return mxid
+
+    def server_name_keys_api(self, server_server_uri):
+        """Retrieve the Matrix server's own homeserver name via the
+        Server-Server (Federation) API.
+
+        Args:
+            server_server_uri (string): proto://name:port or proto://fqdn:port
+
+        Returns:
+            string: The Matrix server's homeserver name or FQDN, usually
+            something like matrix.DOMAIN or DOMAIN
+        """
+        resp = self.query("get", "key/v2/server",
+            base_url_override=server_server_uri
+        )
+        if not resp or not resp.get("server_name"):
+            self.log.error("The homeserver name could not be fetched via the "
+                           "federation API key/v2/server.")
+            return None
+        return resp['server_name']
 
 
 class SynapseAdmin(ApiRequest):

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -151,6 +151,10 @@ class APIHelper:
             self.config["timeout"], self.requests_debug,
             self.config["server_discovery"], self.config["hostname"]
         )
+        self.misc_request = api.MiscRequest(
+            self.log,
+            self.config["timeout"], self.requests_debug,
+        )
         return True
 
     def write_config(self, config):

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -226,7 +226,10 @@ class APIHelper:
                     record[0].target, record[0].port
                 )
                 return self.matrix_api.server_name_keys_api(federation_uri)
-            return None
+        else:
+            self.log.error("Unknown server_discovery mode. "
+                           "Launch synadm config!")
+        return None
 
     def generate_mxid(self, user_id):
         """ Checks whether the given user ID is an MXID already or else

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -182,6 +182,25 @@ class APIHelper:
         """
         click.echo(self.formatter(data))
 
+    def retrieve_homeserver_name(self, uri):
+        """Try to retrieve the homeserver name via .well-known and a
+        Server-Server (Federation) API.
+
+        FIXME: Fall back to a statically configured name in config.yaml or
+        rather use the configured name if present and just don't try to
+        fetch.
+
+        Args:
+            uri (string): proto://name:port or proto://fqdn:port
+
+        Returns:
+            string: hostname, FQDN or DOMAIN; or None on errors.
+        """
+        federation_uri = self.misc_request.server_name_well_known(uri)
+        if not federation_uri:
+            return None
+        return self.matrix_api.server_name_keys_api(federation_uri)
+
 
 @click.group(
     invoke_without_command=False,

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -205,11 +205,21 @@ class APIHelper:
             return  self.config["homeserver"]
 
         if self.config["server_discovery"] == "well-known":
-            federation_uri = self.misc_request.federation_uri_well_known(uri)
-            if not federation_uri:
-                return None
+            if "localhost" in self.config["base_url"]:
+                click.echo("Trying to fetch homeserver name via localhost...")
+                return self.matrix_api.server_name_keys_api(
+                    self.config["base_url"]
+                )
+            else:
+                click.echo(
+                    "Trying to fetch federation URI via well-known resource..."
+                )
+                federation_uri = self.misc_request.federation_uri_well_known(uri)
+                if not federation_uri:
+                    return None
             return self.matrix_api.server_name_keys_api(federation_uri)
         elif self.config["server_discovery"] == "dns":
+            click.echo("Trying to fetch federation URI via DNS SRV record...")
             hostname = urlparse(uri).hostname
             try:
                 record = dns.resolver.query(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -201,17 +201,20 @@ class APIHelper:
             string: hostname, FQDN or DOMAIN; or None on errors.
         """
         uri = uri if uri else self.config["base_url"]
+        echo = self.log.info if self.batch else click.echo
         if self.config["homeserver"] != "auto-retrieval":
             return  self.config["homeserver"]
 
         if self.config["server_discovery"] == "well-known":
             if "localhost" in self.config["base_url"]:
-                click.echo("Trying to fetch homeserver name via localhost...")
+                echo(
+                    "Trying to fetch homeserver name via localhost..."
+                )
                 return self.matrix_api.server_name_keys_api(
                     self.config["base_url"]
                 )
             else:
-                click.echo(
+                echo(
                     "Trying to fetch federation URI via well-known resource..."
                 )
                 federation_uri = self.misc_request.federation_uri_well_known(uri)
@@ -219,7 +222,9 @@ class APIHelper:
                     return None
             return self.matrix_api.server_name_keys_api(federation_uri)
         elif self.config["server_discovery"] == "dns":
-            click.echo("Trying to fetch federation URI via DNS SRV record...")
+            echo(
+                "Trying to fetch federation URI via DNS SRV record..."
+            )
             hostname = urlparse(uri).hostname
             try:
                 record = dns.resolver.query(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -27,6 +27,7 @@ import click
 import yaml
 import tabulate
 from urllib.parse import urlparse
+import dns.resolver
 
 from synadm import api
 

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -26,6 +26,7 @@ import json
 import click
 import yaml
 import tabulate
+from urllib.parse import urlparse
 
 from synadm import api
 
@@ -205,8 +206,12 @@ class APIHelper:
                 return None
             return self.matrix_api.server_name_keys_api(federation_uri)
         elif self.config["server_discovery"] == "dns":
-            self.log.warning("Not implemented yet. FIXME")
-            return None
+            # TODO: Retrieve hostname in another way
+            record = dns.resolver.query(
+                "_matrix._tcp.{}".format(urlparse(uri).hostname), "SRV")
+            print(record)
+            server = str(record[0].target)[:-1]
+            return server
 
 
 @click.group(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -196,10 +196,12 @@ class APIHelper:
         Returns:
             string: hostname, FQDN or DOMAIN; or None on errors.
         """
-        federation_uri = self.misc_request.server_name_well_known(uri)
-        if not federation_uri:
+        federation_servername = self.misc_request.server_name_well_known(uri)
+        if not federation_servername:
             return None
-        return self.matrix_api.server_name_keys_api(federation_uri)
+        return self.matrix_api.server_name_keys_api(
+            "https://" + federation_servername
+        )
 
 
 @click.group(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -189,9 +189,10 @@ class APIHelper:
 
         When homeserver is set in the config already, it's just returned and
         nothing is tried to be fetched automatically. If not, either the
-        location of the federation API is looked up via a .well-known resource
+        location of the Federation API is looked up via a .well-known resource
         or a DNS SRV lookup. This depends on the server_discovery setting in the
-        config.
+        config. Finally the Federation API is used to retrieve the homeserver
+        name.
 
         Args:
             uri (string): proto://name:port or proto://fqdn:port

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -207,12 +207,23 @@ class APIHelper:
                 return None
             return self.matrix_api.server_name_keys_api(federation_uri)
         elif self.config["server_discovery"] == "dns":
-            # TODO: Retrieve hostname in another way
-            record = dns.resolver.query(
-                "_matrix._tcp.{}".format(urlparse(uri).hostname), "SRV")
-            print(record)
-            server = str(record[0].target)[:-1]
-            return server
+            hostname = urlparse(uri).hostname
+            try:
+                record = dns.resolver.query(
+                    "_matrix._tcp.{}".format(hostname),
+                    "SRV"
+                )
+            except Exception as error:
+                self.log.error(
+                    "resolving Matrix delegation for %s: %s: %s",
+                    hostname, type(error).__name__, error
+                )
+            else:
+                federation_uri = "https://{}:{}".format(
+                    record[0].target, record[0].port
+                )
+                return self.matrix_api.server_name_keys_api(federation_uri)
+            return None
 
 
 @click.group(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -403,15 +403,15 @@ def config_cmd(helper, user, token, base_url, admin_path, matrix_path,
             "Default http timeout",
             default=timeout if timeout else helper.config.get(
                 "timeout", timeout)),
+        "homeserver": click.prompt(
+            "Homeserver name, (auto-retrieval or matrix.DOMAIN)",
+            default=homeserver if homeserver else helper.config.get(
+                "homeserver", homeserver)),
         "server_discovery": click.prompt(
-            "Server discovery mode",
+            "Server discovery mode (used with homeserver name auto-retrieval)",
             default=server_discovery if server_discovery else helper.config.get(
                 "server_discovery", server_discovery),
             type=click.Choice(["well-known", "dns"])),
-        "homeserver": click.prompt(
-            "Synapse homeserver name, usually matrix.DOMAIN or DOMAIN",
-            default=homeserver if homeserver else helper.config.get(
-                "homeserver", homeserver))
     })
     if not helper.load():
         click.echo("Configuration incomplete, quitting.")

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -196,12 +196,10 @@ class APIHelper:
         Returns:
             string: hostname, FQDN or DOMAIN; or None on errors.
         """
-        federation_servername = self.misc_request.server_name_well_known(uri)
-        if not federation_servername:
+        federation_uri = self.misc_request.federation_uri_well_known(uri)
+        if not federation_uri:
             return None
-        return self.matrix_api.server_name_keys_api(
-            "https://" + federation_servername
-        )
+        return self.matrix_api.server_name_keys_api(federation_uri)
 
 
 @click.group(

--- a/synadm/cli/matrix.py
+++ b/synadm/cli/matrix.py
@@ -56,7 +56,7 @@ def login_cmd(helper, user_id, password):
         else:
             password = click.prompt("Password", hide_input=True)
 
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     login = helper.matrix_api.user_login(mxid, password)
 
     if helper.batch:

--- a/synadm/cli/media.py
+++ b/synadm/cli/media.py
@@ -224,9 +224,7 @@ def media_delete_cmd(helper, media_id, before_days, before, before_ts,
                      size, delete_profiles):
     """ Delete media by ID, size or age
     """
-    server_name = helper.misc_request.retrieve_homeserver_name(
-        helper.config["base_url"]
-    )
+    server_name = helper.retrieve_homeserver_name(helper.config["base_url"])
     if not server_name:
         media_deleted = None
     elif media_id and delete_profiles:

--- a/synadm/cli/media.py
+++ b/synadm/cli/media.py
@@ -85,7 +85,7 @@ def media_list_cmd(ctx, helper, room_id, user_id, from_, limit, sort, reverse,
         helper.output(media_list)
     elif user_id:
         from synadm.cli import user
-        mxid = helper.matrix_api.generate_mxid(user_id)
+        mxid = helper.generate_mxid(user_id)
         ctx.invoke(
             user.get_function("user_media_cmd"),
             user_id=mxid, from_=from_, limit=limit, sort=sort,
@@ -133,7 +133,7 @@ def media_quarantine_cmd(helper, server_name, media_id, user_id, room_id):
     elif room_id:
         media_quarantined = helper.api.room_media_quarantine(room_id)
     elif user_id:
-        mxid = helper.matrix_api.generate_mxid(user_id)
+        mxid = helper.generate_mxid(user_id)
         media_quarantined = helper.api.user_media_quarantine(mxid)
 
     if media_quarantined is None:

--- a/synadm/cli/media.py
+++ b/synadm/cli/media.py
@@ -224,7 +224,9 @@ def media_delete_cmd(helper, media_id, before_days, before, before_ts,
                      size, delete_profiles):
     """ Delete media by ID, size or age
     """
-    server_name = helper.misc_request.server_name_well_known()
+    server_name = helper.misc_request.retrieve_homeserver_name(
+        helper.config["base_url"]
+    )
     if not server_name:
         media_deleted = None
     elif media_id and delete_profiles:

--- a/synadm/cli/media.py
+++ b/synadm/cli/media.py
@@ -122,7 +122,8 @@ def media_quarantine_cmd(helper, server_name, media_id, user_id, room_id):
     """
     if media_id and not server_name:
         # We assume it is local media and fetch our own server name.
-        fetched_name = helper.matrix_api.server_name()
+        fetched_name = helper.retrieve_homeserver_name(
+            helper.config["base_url"])
         media_quarantined = helper.api.media_quarantine(fetched_name, media_id)
     elif server_name and not media_id:
         click.echo("Media ID missing.")

--- a/synadm/cli/media.py
+++ b/synadm/cli/media.py
@@ -224,7 +224,7 @@ def media_delete_cmd(helper, media_id, before_days, before, before_ts,
                      size, delete_profiles):
     """ Delete media by ID, size or age
     """
-    server_name = helper.matrix_api.server_name()
+    server_name = helper.misc_request.server_name_well_known()
     if not server_name:
         media_deleted = None
     elif media_id and delete_profiles:

--- a/synadm/cli/room.py
+++ b/synadm/cli/room.py
@@ -41,7 +41,7 @@ def room():
 def join(helper, room_id_or_alias, user_id):
     """ Join a room
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     out = helper.api.room_join(room_id_or_alias, mxid)
     helper.output(out)
 
@@ -259,7 +259,7 @@ def delete(ctx, helper, room_id, new_room_user_id, room_name, message, block,
                      type=bool, default=False, show_default=False)
     )
     if sure:
-        mxid = helper.matrix_api.generate_mxid(new_room_user_id)
+        mxid = helper.generate_mxid(new_room_user_id)
         room_del = helper.api.room_delete(
             room_id, mxid, room_name,
             message, block, no_purge)
@@ -312,6 +312,6 @@ def make_admin(helper, room_id, user_id):
     the user.
     """
 
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     out = helper.api.room_make_admin(room_id, mxid)
     helper.output(out)

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -69,7 +69,7 @@ def user():
 def list_user_cmd(helper, from_, limit, guests, deactivated, name, user_id):
     """ List and search for users
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     users = helper.api.user_list(from_, limit, guests, deactivated, name,
                                  mxid)
     if users is None:
@@ -110,7 +110,7 @@ def deactivate(ctx, helper, user_id, gdpr_erase):
     - Password reset
     - Deletion of third-party-IDs (to prevent the user requesting a password)
     """)
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     ctx.invoke(user_details_cmd, user_id=mxid)
     ctx.invoke(membership, user_id=mxid)
     m_erase_or_deact = "gdpr-erase" if gdpr_erase else "deactivate"
@@ -178,7 +178,7 @@ def prune_devices_cmd(helper, user_id, list_only, min_days, min_surviving,
     Note that this will affect the encryption and decryption of messages sent by
     other users to this user or to rooms where the user is present.
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     devices_data = helper.api.user_devices(mxid)
     if "devices" not in devices_data:
         # Most probably the requested user is not existing, show error and quit.
@@ -230,7 +230,7 @@ def password_cmd(helper, user_id, password, no_logout):
 
     To prevent the user from being logged out of all sessions use option -n.
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     changed = helper.api.user_password(mxid, password, no_logout)
     if changed is None:
         click.echo("Password could not be reset.")
@@ -255,7 +255,7 @@ def membership(helper, user_id, aliases):
 
     Provide matrix user ID (@user:server) as argument.
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     joined_rooms = helper.api.user_membership(mxid, aliases,
                                               helper.matrix_api)
     if joined_rooms is None:
@@ -303,7 +303,7 @@ def user_search_cmd(ctx, search_term, from_, limit):
 def user_details_cmd(helper, user_id):
     """ View details of a user account.
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     user_data = helper.api.user_details(mxid)
     if user_data is None:
         click.echo("User details could not be fetched.")
@@ -373,7 +373,7 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
             "Deactivating a user and setting a password doesn't make sense.")
         raise SystemExit(1)
 
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     click.echo("Current user account settings:")
     ctx.invoke(user_details_cmd, user_id=mxid)
     click.echo("User account settings to be modified:")
@@ -432,7 +432,7 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
 def whois(helper, user_id):
     """ Return information about the active sessions for a specific user
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     user_data = helper.api.user_whois(mxid)
     helper.output(user_data)
 
@@ -479,7 +479,7 @@ def user_media_cmd(helper, user_id, from_, limit, sort, reverse, datetime):
     safe_from_quarantine), this can cause a large load on the database,
     especially for large environments
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     media = helper.api.user_media(mxid, from_, limit, sort, reverse,
                                   datetime)
     if media is None:
@@ -541,7 +541,7 @@ def user_login_cmd(helper, user_id, expire_days, expire, expire_ts,
     admin user calls /logout/all from any of their devices, but the token will
     not expire if the target user does the same.
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     if expire_never:
         user_login = helper.api.user_login(mxid, None, None, None)
     elif not expire_days and not expire and not expire_ts:
@@ -583,7 +583,7 @@ def user_shadow_ban(helper, user_id, unban):
 
     Generally, it is more appropriate to ban or kick abusive users.
     """
-    mxid = helper.matrix_api.generate_mxid(user_id)
+    mxid = helper.generate_mxid(user_id)
     user_ban = helper.api.user_shadow_ban(mxid, unban)
     if user_ban is None:
         click.echo("Failed to shadow-ban: {}".format(user_id))


### PR DESCRIPTION
With regards to #68 this PR aims to change the method of retrieving the server name.

Before the keys/v2/server can be used to retrieve our own servername, it's required to know where the Server-Server aka federation API is located. According to the Matrix spec there is [a definite way to achieving that in the matrix spec
](https://spec.matrix.org/v1.2/server-server-api/#resolving-server-names). It was determined that the admin should be given the freedom to configure the methods (well-known and DNS), rather than implementing an auto-fallback as described in the spec. This should help simplify the implementation and increase performance once set up via synadm config.

As part of this change two new config options `homeserver` and `server_discovery` are utilized.
- `homeserver`: by default set to 'auto-retrieval' or otherwise set to a homeserver name, eg. matrix.DOMAIN already, which overrides auto fetching at all. Eg required if a localhost:port uri is configured for admin api access.
- `server_discovery`: Can either be `dns`, meaning the server name is retrieved using the SRV record, or `well-known`, which indicates that the server name is retrieved using the `.well-known/matrix/server` endpoint. The latter should be the default.