### PR TITLE
Add server notice support

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ python3 setup.py install
     * [ ] `room count`
     * [ ] `room top-complexity`
     * [ ] `room top-members`
-* [ ] [Server Notices](https://matrix-org.github.io/synapse/develop/admin_api/server_notices.html)
+* [x] [Server Notices](https://matrix-org.github.io/synapse/develop/admin_api/server_notices.html)
 * [x] ~~[Shutdown Room](https://matrix-org.github.io/synapse/develop/admin_api/shutdown_room.html)~~ (DEPRECATED, covered by `room delete`)
 * [ ] [Statistics](https://matrix-org.github.io/synapse/develop/admin_api/statistics.html)
 * [x] [Users](https://matrix-org.github.io/synapse/develop/admin_api/user_admin_api.html)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -1171,9 +1171,10 @@ class SynapseAdmin(ApiRequest):
                     if not re.search(receivers, user["name"]) is None:
                         data["user_id"] = user["name"]
                         outputs.append(
-                            self.query("post",
-                                       f"v1/send_server_notice", data=data)
-                                      )
+                            self.query(
+                                "post", f"v1/send_server_notice", data=data
+                            )
+                        )
 
                 if "next_token" not in response:
                     return outputs

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -1182,5 +1182,5 @@ class SynapseAdmin(ApiRequest):
                                           100, True, False, "", "")
         # Only a single user ID was supplied as receiver
         else:
-            data["user_id"] = receivers
+            data["user_id"] = generate_mxid(receivers)
             return [self.query("post", f"v1/send_server_notice", data=data)]

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -1168,7 +1168,7 @@ class SynapseAdmin(ApiRequest):
                 return
             while True:
                 for user in response["users"]:
-                    if not re.search(receivers, user["name"]) is None:
+                    if re.match(receivers, user["name"]):
                         data["user_id"] = user["name"]
                         outputs.append(
                             self.query(

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -34,6 +34,8 @@ import datetime
 import json
 import urllib.parse
 import time
+import re
+import click
 
 
 class ApiRequest:
@@ -1139,3 +1141,58 @@ class SynapseAdmin(ApiRequest):
         else:
             method = "post"
         return self.query(method, f"v1/users/{user_id}/shadow_ban")
+
+    def notice_send(self, receivers, content_plain, content_html, batch, paginate):
+        """ Send server notices.
+
+        Args:
+            receivers: Target(s) of the notice. Either localpart or regular 
+                expression matching localparts.
+            content_plain: Unformatted text of the notice.
+            content_html: HTML-formatted text of the notice.
+        """
+        data = {
+                "user_id": "",
+                "content": {
+                        "msgtype": "m.text",
+                        "body": content_plain,
+                        "format": "org.matrix.custom.html",
+                        "formatted_body": content_html
+                }
+        }
+        def ask_confirmation(users):
+            if batch:
+                return True
+            prompt = "Recipients (list may be incomplete):\n"
+            ctr = 0
+            for user in users:
+                if not re.search(receivers, user) is None:
+                    prompt = prompt + " - " + user + "\n"
+                    ctr = ctr + 1
+                    if ctr == 10:
+                        prompt = prompt + " - ..."
+                        break
+            prompt = prompt + "\nUnformatted message:\n---\n" + content_plain + "\n---\nFormatted message:\n---\n" + content_html + "\n---\nSend now?"
+            return click.confirm(prompt)
+
+        # Only a single user ID was supplied as receiver
+        if receivers[:1] == '@':
+            if ask_confirmation([receivers]):
+                data["user_id"] = receivers
+                return [self.query("post", f"v1/send_server_notice", data=data)]
+        # A regular expression was supplied to match receivers.
+        elif receivers[:1] == '^':
+            outputs = []
+            response = self.user_list(0, paginate, True, False, "", "")
+            if ask_confirmation(map(lambda u: u["name"], response["users"])):
+                while True:
+                    for user in response["users"]:
+                        if not re.search(receivers, user["name"]) is None:
+                            data["user_id"] = user["name"]
+                            outputs.append(self.query("post", f"v1/send_server_notice", data=data))
+
+                    if not "next_token" in response:
+                        return outputs
+                    response = self.user_list(response["next_token"], 100, True, False, "", "")
+        else:
+            print("The recipients you specified were neither a matrix ID (starting with an '@'), nor a regular expression (starting with '^').")

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -1144,19 +1144,19 @@ class SynapseAdmin(ApiRequest):
         """ Send server notices.
 
         Args:
-            receivers: Target(s) of the notice. Either localpart or regular 
+            receivers: Target(s) of the notice. Either localpart or regular
                 expression matching localparts.
             content_plain: Unformatted text of the notice.
             content_html: HTML-formatted text of the notice.
         """
         data = {
-                "user_id": "",
-                "content": {
-                        "msgtype": "m.text",
-                        "body": content_plain,
-                        "format": "org.matrix.custom.html",
-                        "formatted_body": content_html
-                }
+            "user_id": "",
+            "content": {
+                "msgtype": "m.text",
+                "body": content_plain,
+                "format": "org.matrix.custom.html",
+                "formatted_body": content_html
+            }
         }
 
         # A regular expression was supplied to match receivers.
@@ -1167,13 +1167,15 @@ class SynapseAdmin(ApiRequest):
                 for user in response["users"]:
                     if not re.search(receivers, user["name"]) is None:
                         data["user_id"] = user["name"]
-                        outputs.append(self.query("post", 
-                            f"v1/send_server_notice", data=data))
+                        outputs.append(
+                            self.query("post",
+                                       f"v1/send_server_notice", data=data)
+                                      )
 
-                if not "next_token" in response:
+                if "next_token" not in response:
                     return outputs
-                response = self.user_list(response["next_token"], 
-                    100, True, False, "", "")
+                response = self.user_list(response["next_token"],
+                                          100, True, False, "", "")
         # Only a single user ID was supplied as receiver
         else:
             data["user_id"] = receivers

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -36,6 +36,7 @@ import urllib.parse
 import time
 import re
 
+
 class ApiRequest:
     """Basic API request handling and helper utilities
 
@@ -1140,7 +1141,7 @@ class SynapseAdmin(ApiRequest):
             method = "post"
         return self.query(method, f"v1/users/{user_id}/shadow_ban")
 
-    def notice_send(self, receivers, content_plain, content_html, paginate):
+    def notice_send(self, receivers, content_plain, content_html, paginate, to_regex):
         """ Send server notices.
 
         Args:
@@ -1160,9 +1161,11 @@ class SynapseAdmin(ApiRequest):
         }
 
         # A regular expression was supplied to match receivers.
-        if receivers[:1] == '^':
+        if to_regex:
             outputs = []
             response = self.user_list(0, paginate, True, False, "", "")
+            if "users" not in response:
+                return
             while True:
                 for user in response["users"]:
                     if not re.search(receivers, user["name"]) is None:

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -260,14 +260,15 @@ class APIHelper:
         """
         if user_id is None:
             return None
-        elif re.match(r"@[-./=\w]+:[-\[\].:\w]+$", user_id):
+        # Briefly check whether a regex has been passed as user_id
+        elif re.search(r"[\[\]*]", user_id):
+            return None
+        elif re.match(r"^@[-./=\w]+:[-.\w]+", user_id):
             return user_id
-        elif re.match(r"[-./=\w]+$", user_id):
+        else:
             localpart = re.sub("[@:]", "", user_id)
             mxid = "@{}:{}".format(localpart, self.retrieve_homeserver_name())
             return mxid
-        else:
-            return None
 
 
 

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -458,4 +458,4 @@ def version(helper):
 
 
 # Import additional commands
-from synadm.cli import room, user, media, group, history, matrix, regtok
+from synadm.cli import room, user, media, group, history, matrix, regtok, notice

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -260,12 +260,14 @@ class APIHelper:
         """
         if user_id is None:
             return None
-        elif re.match(r"@[-./=\w]+:[-.\w]+", user_id):
+        elif re.match(r"@[-./=\w]+:[-\[\].:\w]+$", user_id):
             return user_id
-        else:
+        elif re.match(r"[-./=\w]+$", user_id):
             localpart = re.sub("[@:]", "", user_id)
             mxid = "@{}:{}".format(localpart, self.retrieve_homeserver_name())
             return mxid
+        else:
+            return None
 
 
 

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -256,19 +256,24 @@ class APIHelper:
 
         Returns:
             string: the fully qualified Matrix User ID (MXID) or None if the
-                user_id parameter is None.
+                user_id parameter is None or no regex matched.
         """
         if user_id is None:
+            self.log.debug("Missing input in generate_mxid().")
             return None
-        # Briefly check whether a regex has been passed as user_id
-        elif re.search(r"[\[\]*]", user_id):
-            return None
-        elif re.match(r"^@[-./=\w]+:[-.\w]+", user_id):
+        elif re.match(r"^@[-./=\w]+:[-\[\].:\w]+$", user_id):
+            self.log.debug("A proper MXID was passed.")
             return user_id
-        else:
+        elif re.match(r"^@?[-./=\w]+:?$", user_id):
+            self.log.debug("A proper localpart was passed, generating MXID "
+                           "for local homeserver.")
             localpart = re.sub("[@:]", "", user_id)
             mxid = "@{}:{}".format(localpart, self.retrieve_homeserver_name())
             return mxid
+        else:
+            self.log.error("Neither an MXID nor a proper localpart was "
+                           "passed.")
+            return None
 
 
 

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -64,21 +64,6 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, match_list_length,
     FORMATTED - Formatted content of the notice. If not set, PLAIN will be
         used.
     """
-    if from_file:
-        with open(plain, "r") as plain_file:
-            plain_content = plain_file.read()
-        if formatted:
-            with open(formatted, "r") as formatted_file:
-                formatted_content = formatted_file.read()
-        else:
-            formatted_content = plain_content
-    else:
-        plain_content = plain
-        if formatted is None:
-            formatted_content = plain
-        else:
-            formatted_content = formatted
-
     def confirm_prompt():
         if helper.batch:
             return True
@@ -112,6 +97,21 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, match_list_length,
             + "\n---\nFormatted message:\n---\n" + formatted_content\
             + "\n---\nSend now?"
         return click.confirm(prompt)
+
+    if from_file:
+        with open(plain, "r") as plain_file:
+            plain_content = plain_file.read()
+        if formatted:
+            with open(formatted, "r") as formatted_file:
+                formatted_content = formatted_file.read()
+        else:
+            formatted_content = plain_content
+    else:
+        plain_content = plain
+        if formatted is None:
+            formatted_content = plain
+        else:
+            formatted_content = formatted
 
     if to_regex:
         if "users" not in helper.api.user_list(0, 100, True, False, "", ""):

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -31,12 +31,12 @@ def notice():
     """
 
 @notice.command(name="send")
-@click.option("--from-file/--from-argument", "-f/-a", default=False,
-    help="""Interpret arguments as file paths instead of notice content and 
-    read content from those files""")
-@click.option("--paginate", type=int, default=100,
+@click.option("--from-file", "-f", default=False, show_default=True
+    is_flag=True, help="""Interpret arguments as file paths instead of notice
+    content and read content from those files""")
+@click.option("--paginate", type=int, default=100, show_default=True,
     help="Sets how many users will be retrieved from the server at once")
-@click.option("--to-regex", "-r", default=False, show_default=True, 
+@click.option("--to-regex", "-r", default=False, show_default=True,
     is_flag=True, help="Interpret TO as regular expression")
 @click.argument("to", type=str, default=None)
 @click.argument("plain", type=str, default=None)
@@ -50,8 +50,8 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, to, plain, formatted)
     
     PLAIN - plain text content of the notice
     
-    FORMATTED - (HTML-) formatted content of the notice. If not set, PLAIN 
-        will be used.
+    FORMATTED - Formatted content of the notice. If not set, PLAIN will be
+        used.
     """
     if from_file:
         with open(plain, "r") as plain_file:
@@ -80,13 +80,13 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, to, plain, formatted)
                     if ctr >= 10:
                         prompt = prompt + " - ..."
                         break
-            prompt = prompt + "\nUnformatted message:\n---\n" + plain_content\
+            prompt = prompt + "\Plaintext message:\n---\n" + plain_content\
                 + "\n---\nFormatted message:\n---\n" + formatted_content\
                 + "\n---\nSend now?"
             return click.confirm(prompt)
     
     if to_regex:
-        first_batch = helper.api.user_list(0, paginate, True, False, "", "")
+        first_batch = helper.api.user_list(0, 100, True, False, "", "")
         if "users" not in first_batch:
             return
         if not confirm_prompt([user['name'] for user in first_batch["users"]]):

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -82,7 +82,7 @@ def notice_send_cmd(helper, from_file, paginate, to, plain, formatted):
     
     if to[:1] == '^':
         first_batch = helper.api.user_list(0, paginate, True, False, "", "")
-        if not confirm_prompt(map(lambda u: u["name"], first_batch["users"])):
+        if not confirm_prompt([user['name'] for user in first_batch["users"]]):
             return
     else:
         to = helper.generate_mxid(to)

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -31,14 +31,18 @@ def notice():
 
 
 @notice.command(name="send")
-@click.option("--from-file", "-f", default=False, show_default=True,
-    is_flag=True, help="""Interpret arguments as file paths instead of notice
-    content and read content from those files""")
-@click.option("--paginate", type=int, default=100, show_default=True,
-    help="Sets how many users will be retrieved from the server at once")
-@click.option("--to-regex", "-r", default=False, show_default=True,
-    is_flag=True, help="Interpret TO as regular expression")
-@click.option("--match-list-length", type=int, default=10, show_default=True,
+@click.option(
+    "--from-file", "-f", default=False, show_default=True, is_flag=True,
+    help="""Interpret arguments as file paths instead of notice content and
+    read content from those files""")
+@click.option(
+    "--paginate", type=int, default=100, show_default=True, help="""Sets how
+    many users will be retrieved from the server at once""")
+@click.option(
+    "--to-regex", "-r", default=False, show_default=True, is_flag=True,
+    help="Interpret TO as regular expression")
+@click.option(
+    "--match-list-length", "-l", type=int, default=10, show_default=True,
     help="""Length of the displayed list of matched receivers. Does not impact
     sending behavior""")
 @click.argument("to", type=str, default=None)

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -121,6 +121,7 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, match_list_length,
     else:
         to = helper.generate_mxid(to)
         if to is None:
+            print("The recipient you specified is invalid.")
             return
         if not confirm_prompt():
             return

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -93,6 +93,8 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, match_list_length,
                 if "next_token" not in batch:
                     break
                 next_token = batch["next_token"]
+            if ctr == 0:
+                prompt = prompt + "(no recipient matched)\n"
         prompt = prompt + "\nPlaintext message:\n---\n" + plain_content\
             + "\n---\nFormatted message:\n---\n" + formatted_content\
             + "\n---\nSend now?"

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# synadm
+# Copyright (C) 2020-2022 Philip (a-0)
+#
+# synadm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# synadm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""server notice-related CLI commands
+"""
+
+import click
+from click_option_group import optgroup, MutuallyExclusiveOptionGroup
+from click_option_group import RequiredAnyOptionGroup
+
+from synadm import cli
+
+@cli.root.group()
+def notice():
+    """ Send server notices to local users
+    """
+
+@notice.command(name="send")
+@click.option("--from-file/--from-argument", "-f/-a", default=False,
+    help="Interpret arguments as file paths instead of notice content and read content from those files")
+@click.option("--batch", "--non-interactive", is_flag=True, default=False,
+    help="Skip the confirmation step before sending notices")
+@click.option("--paginate", type=int, default=100,
+    help="Sets how many users will be retrieved from the server at once")
+@click.argument("to", type=str, default=None)
+@click.argument("plain", type=str, default=None)
+@click.argument("formatted", type=str, default=None, required=False)
+@click.pass_obj
+def notice_send_cmd(helper, from_file, batch, paginate, to, plain, formatted):
+    """Send server notices to local users.
+
+    TO - either a matrix ID (e.g. '@abc:example.com') or a regular expression as used in python (e.g. '^.*' to send to all users)
+    
+    PLAIN - plain text content of the notice
+    
+    FORMATTED - (HTML-) formatted content of the notice. If not set, PLAIN will be used.
+    """
+    if from_file:
+        plain_content = open(plain, "r").read()
+        if formatted:
+            formatted_content = open(formatted, "r").read()
+        else:
+            formatted_content = plain_content
+    else:
+        plain_content = plain
+        formatted_content = formatted
+    
+    helper.api.notice_send(to, plain_content, formatted_content, batch, paginate)

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -95,7 +95,7 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, match_list_length,
                 batch_mxids = [user['name'] for user in batch["users"]]
                 # Match every matrix ID of this batch
                 for mxid in batch_mxids:
-                    if not re.search(to, mxid) is None:
+                    if re.match(to, mxid):
                         if ctr < match_list_length:
                             prompt = prompt + " - " + mxid + "\n"
                             ctr = ctr + 1
@@ -117,6 +117,8 @@ def notice_send_cmd(helper, from_file, paginate, to_regex, match_list_length,
             return
     else:
         to = helper.generate_mxid(to)
+        if to is None:
+            return
         if not confirm_prompt():
             return
 

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -36,8 +36,11 @@ def notice():
     help="""Interpret arguments as file paths instead of notice content and
     read content from those files""")
 @click.option(
-    "--paginate", type=int, default=100, show_default=True, help="""Sets how
-    many users will be retrieved from the server at once""")
+    "--paginate", "-p", type=int, default=100, show_default=True, help="""The
+    send command retrieves pages of users from the homeserver, filters them
+    and sends out the notices, before retrieving the next page. paginate sets
+    how many users are in each of these "pages". It is a performance setting
+    and may be useful for servers with a large amount of users.""")
 @click.option(
     "--to-regex", "-r", default=False, show_default=True, is_flag=True,
     help="Interpret TO as regular expression")

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -46,8 +46,8 @@ def notice():
     help="Interpret TO as regular expression")
 @click.option(
     "--match-list-length", "-l", type=int, default=10, show_default=True,
-    help="""Length of the displayed list of matched receivers. Does not impact
-    sending behavior""")
+    help="""Length of the displayed list of matched recipients shown in the
+    confirmation prompt. Does not impact sending behavior""")
 @click.argument("to", type=str, default=None)
 @click.argument("plain", type=str, default=None)
 @click.argument("formatted", type=str, default=None, required=False)


### PR DESCRIPTION
Implemented features (for now):
- Send to single matrix IDs or to all mxids matching a regular expression
- Uses pagination when sending to multiple users (batches of 100 by default, tunable by CLI option)
- Specify notice content in command arguments or in files
- Supports both unformatted and unformatted+formatted message content
- Asks for confirmation (including message content and sample mxids the notice will be sent to) by default before sending - can be disabled by flag