### PR TITLE
add command auth-provider for finding users by their external id on auth provider

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -667,7 +667,8 @@ class SynapseAdmin(ApiRequest):
         """ Finds a user based on their ID (external id) in auth provider
         represented by auth provider id (provider).
         """
-        return self.query("get", f"v1/auth_providers/{provider}/users/{external_id}")
+        return self.query("get",
+                          f"v1/auth_providers/{provider}/users/{external_id}")
 
     def room_join(self, room_id_or_alias, user_id):
         """ Allow an administrator to join an user account with a given user_id

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -663,6 +663,12 @@ class SynapseAdmin(ApiRequest):
         return self.query("post", f"v2/users/{user_id}/delete_devices",
                           data={"devices": devices})
 
+    def user_auth_provider_search(self, provider, external_id):
+        """ Finds a user based on their ID (external id) in auth provider
+        represented by auth provider id (provider).
+        """
+        return self.query("get", f"v1/auth_providers/{provider}/users/{external_id}")
+
     def room_join(self, room_id_or_alias, user_id):
         """ Allow an administrator to join an user account with a given user_id
         to a room with a given room_id_or_alias

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -617,10 +617,4 @@ def auth_provider_search(helper, provider, external_id):
     Finds a user based on their ID (external id) in auth provider represented
     by auth provider id (provider).
     """
-    user = helper.api.user_auth_provider_search(provider, external_id)
-    if user is None:
-        click.echo("No results found: provider={} external_id={}"
-                   .format(external_id, provider))
-        raise SystemExit(1)
-
-    helper.output(user)
+    helper.output(helper.api.user_auth_provider_search(provider, external_id))

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -613,8 +613,9 @@ def user_shadow_ban(helper, user_id, unban):
 )
 @click.pass_obj
 def auth_provider_search(helper, provider, external_id):
-    """ Finds a user based on their ID (external id) in auth provider
-        represented by auth provider id (provider).
+    """Find a user based on their auth-provider ID.
+    Finds a user based on their ID (external id) in auth provider represented
+    by auth provider id (provider).
     """
     user = helper.api.user_auth_provider_search(provider, external_id)
     if user is None:

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -606,9 +606,10 @@ def user_shadow_ban(helper, user_id, unban):
 @user.command(name="auth-provider")
 @click.argument("external_id", type=str)
 @click.option(
-    "-p", "--provider", is_flag=False, required=True, default=None, show_default=True,
-    help="Searches the user by external ID for an auth-provider represented by ID "
-         "as advertised in supported authenticated methods in `m.login.sso` api response"
+    "-p", "--provider", is_flag=False, required=True, default=None,
+    show_default=True, help="""Searches the user by external ID for an
+    auth-provider represented by ID as advertised in supported authenticated
+    methods in `m.login.sso` api response"""
 )
 @click.pass_obj
 def auth_provider_search(helper, provider, external_id):
@@ -617,7 +618,8 @@ def auth_provider_search(helper, provider, external_id):
     """
     user = helper.api.user_auth_provider_search(provider, external_id)
     if user is None:
-        click.echo("No results found: provider={} external_id={}".format(external_id, provider))
+        click.echo("No results found: provider={} external_id={}"
+                   .format(external_id, provider))
         raise SystemExit(1)
 
     helper.output(user)

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -607,9 +607,9 @@ def user_shadow_ban(helper, user_id, unban):
 @click.argument("external_id", type=str)
 @click.option(
     "-p", "--provider", is_flag=False, required=True, default=None,
-    show_default=True, help="""Searches the user by external ID for an
-    auth-provider represented by ID as advertised in supported authenticated
-    methods in `m.login.sso` api response"""
+    show_default=True, help="""Provider ID as advertised in supported
+    authenticated methods in `m.login.sso` api response such as 'oidc' or
+    'google' or 'github'"""
 )
 @click.pass_obj
 def auth_provider_search(helper, provider, external_id):

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -620,4 +620,6 @@ def auth_provider_search(helper, provider, external_user_id):
     authenticated methods in `m.login.sso` api response such as 'oidc' or
     'google' or 'github'.
     """
-    helper.output(helper.api.user_auth_provider_search(provider, external_user_id))
+    helper.output(
+        helper.api.user_auth_provider_search(provider, external_user_id)
+    )

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -606,7 +606,7 @@ def user_shadow_ban(helper, user_id, unban):
 @user.command(name="auth-provider")
 @click.argument("external_id", type=str)
 @click.option(
-    "-p", "--provider", is_flag=False, default=None, show_default=True,
+    "-p", "--provider", is_flag=False, required=True, default=None, show_default=True,
     help="Searches the user by external ID for an auth-provider represented by ID "
          "as advertised in supported authenticated methods in `m.login.sso` api response"
 )
@@ -615,9 +615,6 @@ def auth_provider_search(helper, provider, external_id):
     """ Finds a user based on their ID (external id) in auth provider
         represented by auth provider id (provider).
     """
-    if provider is None:
-        click.echo("You must provide a value for provider using --provider")
-        raise SystemExit(1)
     user = helper.api.user_auth_provider_search(provider, external_id)
     if user is None:
         click.echo("No results found: provider={} external_id={}".format(external_id, provider))

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -601,3 +601,26 @@ def user_shadow_ban(helper, user_id, unban):
             click.echo("Successfully {}ned user: {}".format(action, user_id))
     else:
         helper.output(user_ban)
+
+
+@user.command(name="auth-provider")
+@click.argument("external_id", type=str)
+@click.option(
+    "-p", "--provider", is_flag=False, default=None, show_default=True,
+    help="Searches the user by external ID for an auth-provider represented by ID "
+         "as advertised in supported authenticated methods in `m.login.sso` api response"
+)
+@click.pass_obj
+def auth_provider_search(helper, provider, external_id):
+    """ Finds a user based on their ID (external id) in auth provider
+        represented by auth provider id (provider).
+    """
+    if provider is None:
+        click.echo("You must provide a value for provider using --provider")
+        raise SystemExit(1)
+    user = helper.api.user_auth_provider_search(provider, external_id)
+    if user is None:
+        click.echo("No results found: provider={} external_id={}".format(external_id, provider))
+        raise SystemExit(1)
+
+    helper.output(user)

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -604,7 +604,7 @@ def user_shadow_ban(helper, user_id, unban):
 
 
 @user.command(name="auth-provider")
-@click.argument("external_id", type=str)
+@click.argument("external_user_id", type=str)
 @click.option(
     "-p", "--provider", is_flag=False, required=True, default=None,
     show_default=True, help="""Provider ID as advertised in supported
@@ -612,9 +612,12 @@ def user_shadow_ban(helper, user_id, unban):
     'google' or 'github'"""
 )
 @click.pass_obj
-def auth_provider_search(helper, provider, external_id):
-    """Find a user based on their auth-provider ID.
-    Finds a user based on their ID (external id) in auth provider represented
-    by auth provider id (provider).
+def auth_provider_search(helper, provider, external_user_id):
+    """Find a user based on their ID in auth-provider.
+
+    Finds a user based on their external user ID in a particular auth provider
+    where provider is the auth provider ID as advertised in supported
+    authenticated methods in `m.login.sso` api response such as 'oidc' or
+    'google' or 'github'.
     """
-    helper.output(helper.api.user_auth_provider_search(provider, external_id))
+    helper.output(helper.api.user_auth_provider_search(provider, external_user_id))


### PR DESCRIPTION
This PR adds support for admin endpoint for finding users by their external id on auth provider, which was added in Synapse v1.68.0

Unlike other endpoints, it requires 2 values:
- auth provider id
- external id for the user

> [Documentation for this admin api endpoint](https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#find-a-user-based-on-their-id-in-an-auth-provider)

#### Correct usage
```
$ synadm user auth-provider -p oidc ash
{"user_id": "@ashfame:synapse.dev"}
```

#### Incorrect usage
```
$ synadm user auth-provider ash
You must provide a value for provider using --provider

$ synadm user auth-provider
Usage: synadm user auth-provider [OPTIONS] EXTERNAL_ID
Try 'synadm user auth-provider -h' for help.

Error: Missing argument 'EXTERNAL_ID'.
```

Looking forward to your feedback!

Subsequent PR to follow up for similar lookup for 3PID that's merged but not released (Coming in Synapse v1.72.0) and then we can evaluate if we should add shortcuts for them under search or something else.