### PR TITLE
add command 3pid for finding user by their 3PID

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -670,6 +670,12 @@ class SynapseAdmin(ApiRequest):
         return self.query("get",
                           f"v1/auth_providers/{provider}/users/{external_id}")
 
+    def user_3pid_search(self, medium, address):
+        """ Finds a user based on their Third Party ID by specifying what kind
+        of 3PID it is as medium.
+        """
+        return self.query("get", f"v1/threepid/{medium}/users/{address}")
+
     def room_join(self, room_id_or_alias, user_id):
         """ Allow an administrator to join an user account with a given user_id
         to a room with a given room_id_or_alias

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -623,3 +623,20 @@ def auth_provider_search(helper, provider, external_user_id):
     helper.output(
         helper.api.user_auth_provider_search(provider, external_user_id)
     )
+
+
+@user.command(name="3pid")
+@click.argument("address", type=str)
+@click.option(
+    "-m", "--medium", is_flag=False, required=True, default="email",
+    show_default=True, help="""Medium specifies what kind of Third Party ID is
+    used such as 'email' or 'msidn'"""
+)
+@click.pass_obj
+def third_party_id_search(helper, medium, address):
+    """Find a user based on their Third Party ID.
+
+    Finds a user based on their Third Party ID (3PID) where medium is the kind
+    of Third Party ID that is used such as 'email' or 'msidn'.
+    """
+    helper.output(helper.api.user_auth_provider_search(medium, address))


### PR DESCRIPTION
This PR adds support for 3PID endpoint for finding users by their 3PID value which could be an `email` or `msidn` (specified as medium).

Please note this requires Synapse v1.72.0 (I currently haven't been able to test this as our EMS server is still v1.71.0 and would get upgraded hopefully next week but this is relatively straight forward).

Unlike other endpoints but similar to auth-provider endpoint, it requires 2 values:

- medium (`email` or `msidn`)
- address (actual email address or phone number as per medium specified)

> [Documentation for this admin api endpoint](https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#find-a-user-based-on-their-third-party-id-threepid-or-3pid)

#### Correct usage
```
$ synadm user 3pid -m email universe@github.com
{"user_id": "@ashfame:synapse.dev"}
```

Looking forward to your feedback! :)