### PR TITLE
Correction: use the right function

### DIFF
--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -639,4 +639,4 @@ def third_party_id_search(helper, medium, address):
     Finds a user based on their Third Party ID (3PID) where medium is the kind
     of Third Party ID that is used such as 'email' or 'msidn'.
     """
-    helper.output(helper.api.user_auth_provider_search(medium, address))
+    helper.output(helper.api.user_3pid_search(medium, address))


### PR DESCRIPTION
PR fixes the correct function name to be invoked in 3pid command added in last PR (#81).

Not sure what happened but feels like deja vu. I made this change earlier as well 🤷 

Sorry about this. I have now tested this with Synapse v1.72.0 and it works fine.