### PR TITLE
Add ssl_verify to manage selfsigned certificate

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -57,7 +57,7 @@ class ApiRequest:
             timeout (int): requests module timeout used in query method
             debug (bool): enable/disable debugging in requests module
             verify(bool): SSL verification is turned on by default
-                and can be turned off using this method.
+                and can be turned off using this argument.
         """
         self.log = log
         self.user = user
@@ -389,7 +389,7 @@ class SynapseAdmin(ApiRequest):
                 method
             debug (bool): enable/disable debugging in requests module
             verify(bool): SSL verification is turned on by default
-                and can be turned off using this method.
+                and can be turned off using this argument.
         """
         super().__init__(
             log, user, token,

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -41,7 +41,8 @@ class ApiRequest:
 
     This is subclassed by SynapseAdmin and Matrix
     """
-    def __init__(self, log, user, token, base_url, path, timeout, debug):
+    def __init__(self, log, user, token, base_url, path, timeout, debug,
+                 verify=None):
         """Initialize an APIRequest object
 
         Args:
@@ -55,6 +56,8 @@ class ApiRequest:
                 base_url to form the basis for all API endpoint paths
             timeout (int): requests module timeout used in query method
             debug (bool): enable/disable debugging in requests module
+            verify(bool): SSL verification is turned on by default
+                and can be turned off using this method.
         """
         self.log = log
         self.user = user
@@ -68,9 +71,10 @@ class ApiRequest:
         self.timeout = timeout
         if debug:
             HTTPConnection.debuglevel = 1
+        self.verify = verify
 
     def query(self, method, urlpart, params=None, data=None, token=None,
-              base_url_override=None, verify=True):
+              base_url_override=None, verify=None):
         """Generic wrapper around requests methods.
 
         Handles requests methods, logging and exceptions.
@@ -108,10 +112,14 @@ class ApiRequest:
             self.log.debug("Token override! Adjusting headers.")
             self.headers["Authorization"] = "Bearer " + token
 
+        override_verify = self.verify
+        if verify is not None:
+            override_verify = verify
+
         try:
             resp = getattr(requests, method)(
                 url, headers=self.headers, timeout=self.timeout,
-                params=params, json=data, verify=verify
+                params=params, json=data, verify=override_verify
             )
             if not resp.ok:
                 self.log.warning(f"{host_descr} returned status code "
@@ -196,7 +204,7 @@ class MiscRequest(ApiRequest):
         ApiRequest (object): parent class containing general properties and
             methods for requesting REST API's
     """
-    def __init__(self, log, timeout, debug):
+    def __init__(self, log, timeout, debug, verify=None):
         """Initialize the MiscRequest object
 
         Args:
@@ -204,11 +212,13 @@ class MiscRequest(ApiRequest):
             timeout (int): requests module timeout used in ApiRequest.query
                 method
             debug (bool): enable/disable debugging in requests module
+            verify(bool): SSL verification is turned on by default
+                and can be turned off using this method.
         """
         super().__init__(
             log, "", "",  # Set user and token to empty string
             "", "",  # Set base_url and path to empty string
-            timeout, debug
+            timeout, debug, verify
         )
 
     def federation_uri_well_known(self, base_url):
@@ -243,7 +253,7 @@ class Matrix(ApiRequest):
             methods for requesting REST API's
     """
     def __init__(self, log, user, token, base_url, matrix_path,
-                 timeout, debug):
+                 timeout, debug, verify):
         """Initialize the Matrix API object
 
         Args:
@@ -258,11 +268,13 @@ class Matrix(ApiRequest):
             timeout (int): requests module timeout used in ApiRequest.query
                 method
             debug (bool): enable/disable debugging in requests module
+            verify(bool): SSL verification is turned on by default
+                and can be turned off using this method.
         """
         super().__init__(
             log, user, token,
             base_url, matrix_path,
-            timeout, debug
+            timeout, debug, verify
         )
         self.user = user
 
@@ -360,7 +372,8 @@ class SynapseAdmin(ApiRequest):
         ApiRequest (object): parent class containing general properties and
             methods for requesting REST API's
     """
-    def __init__(self, log, user, token, base_url, admin_path, timeout, debug):
+    def __init__(self, log, user, token, base_url, admin_path, timeout, debug,
+                 verify):
         """Initialize the SynapseAdmin object
 
         Args:
@@ -375,11 +388,13 @@ class SynapseAdmin(ApiRequest):
             timeout (int): Requests module timeout used in ApiRequest.query
                 method
             debug (bool): enable/disable debugging in requests module
+            verify(bool): SSL verification is turned on by default
+                and can be turned off using this method.
         """
         super().__init__(
             log, user, token,
             base_url, admin_path,
-            timeout, debug
+            timeout, debug, verify
         )
         self.user = user
 

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -386,7 +386,7 @@ def root(ctx, verbose, batch, output, config_file):
     method set by --server-discovery."""
 )
 @click.option(
-    "--ssl_verify", "-n",  default=True, show_default=True,
+    "--ssl-verify", "-i",  is_flag=True, default=True, show_default=True,
     help="""Whether or not SSL certificates should be verified. Set to False
     to allow self-signed certifcates."""
 )

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -469,6 +469,7 @@ def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,
                 "homeserver", homeserver)),
         "ssl_verify": click.prompt(
             "Verify certificate",
+            type=bool,
             default=ssl_verify if ssl_verify else helper.config.get(
                 "ssl_verify", ssl_verify)),
         "server_discovery": click.prompt(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -387,8 +387,8 @@ def root(ctx, verbose, batch, output, config_file):
 )
 @click.option(
     "--ssl_verify", "-n",  default=True, show_default=True,
-    help="""Whether or not SSL certificates should be verified. \
-        Set to False to allow self-signed certifcates."""
+    help="""Whether or not SSL certificates should be verified. Set to False
+    to allow self-signed certifcates."""
 )
 @click.pass_obj
 def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -393,7 +393,7 @@ def root(ctx, verbose, batch, output, config_file):
 @click.pass_obj
 def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,
                output, timeout, server_discovery, homeserver, ssl_verify):
-    """ Modify test synadm's configuration.
+    """ Modify synadm's configuration.
 
     Configuration details are generally always asked interactively. Command
     line options override the suggested defaults in the prompts.

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -130,7 +130,12 @@ class APIHelper:
         except Exception as error:
             self.log.error("%s while reading configuration file", error)
         for key, value in self.config.items():
-            if value is None:
+
+            if key == "ssl_verify" and type(value) != bool:
+                self.log.error("Config value error: %s, %s must be boolean",
+                               key, value)
+
+            if not value and type(value) != bool:
                 self.log.error("Config entry missing: %s, %s", key, value)
                 return False
             else:
@@ -381,9 +386,9 @@ def root(ctx, verbose, batch, output, config_file):
     method set by --server-discovery."""
 )
 @click.option(
-    "--ssl_verify", "-n",  default=True,
-    help="""Verify certificate (Default True, False allow to manage \
-        selfsigned certificate)."""
+    "--ssl_verify", "-n",  default=True, show_default=True,
+    help="""Whether or not SSL certificates should be verified. \
+        Set to False to allow self-signed certifcates."""
 )
 @click.pass_obj
 def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,
@@ -463,8 +468,7 @@ def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,
             default=homeserver if homeserver else helper.config.get(
                 "homeserver", homeserver)),
         "ssl_verify": click.prompt(
-            "Verify certificate (Default True, False allow to manage \
-                selfsigned certificate)",
+            "Verify certificate",
             default=ssl_verify if ssl_verify else helper.config.get(
                 "ssl_verify", ssl_verify)),
         "server_discovery": click.prompt(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -386,7 +386,7 @@ def root(ctx, verbose, batch, output, config_file):
     method set by --server-discovery."""
 )
 @click.option(
-    "--ssl-verify", "-i",  is_flag=True, default=True, show_default=True,
+    "--ssl-verify", "-i",  is_flag=True, show_default=True,
     help="""Whether or not SSL certificates should be verified. Set to False
     to allow self-signed certifcates."""
 )


### PR DESCRIPTION
Allow to param ssl_verify in configuration, allow to request https localhost homeserver with self signed certificate.

`~/.config/synadm.yaml`

```
ssl_verify: False
```


Signed-off-by: sebastien.heurtematte <sebastien.heurtematte@eclipse-foundation.org>