### PR TITLE
Make it possible to change user type

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -557,7 +557,8 @@ class SynapseAdmin(ApiRequest):
         if deactivation == "activate":
             data.update({"deactivated": False})
         if user_type:
-            data.update({"user_type": None if 'null' else user_type})
+            data.update({"user_type": None if user_type == 'null' else
+                         user_type})
         return self.query("put", f"v2/users/{user_id}", data=data)
 
     def user_whois(self, user_id):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -556,7 +556,8 @@ class SynapseAdmin(ApiRequest):
             data.update({"deactivated": True})
         if deactivation == "activate":
             data.update({"deactivated": False})
-        data.update({"user_type": user_type})
+        if user_type:
+            data.update({"user_type": user_type})
         return self.query("put", f"v2/users/{user_id}", data=data)
 
     def user_whois(self, user_id):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -557,7 +557,10 @@ class SynapseAdmin(ApiRequest):
         if deactivation == "activate":
             data.update({"deactivated": False})
         if user_type:
-            data.update({"user_type": user_type})
+            if user_type == 'null':
+                data.update({"user_type": None})
+            else:
+                data.update({"user_type": user_type})
         return self.query("put", f"v2/users/{user_id}", data=data)
 
     def user_whois(self, user_id):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -557,10 +557,7 @@ class SynapseAdmin(ApiRequest):
         if deactivation == "activate":
             data.update({"deactivated": False})
         if user_type:
-            if user_type == 'null':
-                data.update({"user_type": None})
-            else:
-                data.update({"user_type": user_type})
+            data.update({"user_type": None if 'null' else user_type})
         return self.query("put", f"v2/users/{user_id}", data=data)
 
     def user_whois(self, user_id):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -534,7 +534,7 @@ class SynapseAdmin(ApiRequest):
         return self.query("post", f"v1/users/{user_id}/login", data=data)
 
     def user_modify(self, user_id, password, display_name, threepid,
-                    avatar_url, admin, deactivation):
+                    avatar_url, admin, deactivation, user_type):
         """ Create or update information about a given user
 
         Threepid should be passed as a tuple in a tuple
@@ -556,6 +556,7 @@ class SynapseAdmin(ApiRequest):
             data.update({"deactivated": True})
         if deactivation == "activate":
             data.update({"deactivated": False})
+        data.update({"user_type": user_type})
         return self.query("put", f"v2/users/{user_id}", data=data)
 
     def user_whois(self, user_id):

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -359,17 +359,17 @@ class UserModifyOptionGroup(RequiredAnyOptionGroup):
     of all rooms and deletes third-party identifiers (to prevent the user
     requesting a password reset). See also "user deactivate" command.""")
 @optgroup.option(
-    "--user-type", "user_type", type=str,
-    help="""Change the type of the user. Currently allowed values are 'bot'
-    and 'support'.""")
-@optgroup.option(
-    "--clear-user-type", "clear_user_type", is_flag=True,
-    help="""Clear the user_type field of the user.""")
+    "--user-type", type=str, default=None, show_default=True,
+    help="""Change the type of the user. Currently understood by the Admin API
+    are 'bot' and 'support'. Use 'regular' to create a regular Matrix user
+    (which effectively sets the user-type to 'null'). If the --user-type option
+    is omitted when modifying an existing user, the user-type will not be
+    manipulated. If the --user-type option is omitted when creating a new user,
+    a regular user will be created.""")
 @click.pass_obj
 @click.pass_context
 def modify(ctx, helper, user_id, password, password_prompt, display_name,
-           threepid, avatar_url, admin, deactivation, user_type,
-           clear_user_type):
+           threepid, avatar_url, admin, deactivation, user_type):
     """ Create or modify a local user. Provide matrix user ID (@user:server)
     as argument.
     """
@@ -380,10 +380,6 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
     if deactivation == "deactivate" and (password_prompt or password):
         click.echo(
             "Deactivating a user and setting a password doesn't make sense.")
-        raise SystemExit(1)
-
-    if clear_user_type and user_type:
-        click.echo("Use either --user-type or --clear-user-type, not both.")
         raise SystemExit(1)
 
     mxid = helper.generate_mxid(user_id)
@@ -402,9 +398,8 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
                             f"{t_key} is probably not a supported medium "
                             "type. Threepid medium types according to the "
                             "current matrix spec are: email, msisdn.")
-        elif key == "clear_user_type":
-            if value:
-                click.echo("user_type: null")
+        elif key == "user_type" and value == 'regular':
+            click.echo("user_type: null")
         elif value not in [None, {}, []]:  # only show non-empty (aka changed)
             click.echo(f"{key}: {value}")
 
@@ -427,7 +422,7 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
         modified = helper.api.user_modify(
             mxid, password, display_name, threepid,
             avatar_url, admin, deactivation,
-            None if clear_user_type else user_type)
+            None if user_type == 'regular' else user_type)
         if modified is None:
             click.echo("User could not be modified.")
             raise SystemExit(1)

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -361,7 +361,7 @@ class UserModifyOptionGroup(RequiredAnyOptionGroup):
 @optgroup.option(
     "--user-type", "user_type", type=str,
     help="""Change the type of the user. Currently allowed values are 'bot'
-    and support.""")
+    and 'support'.""")
 @optgroup.option(
     "--clear-user-type", "clear_user_type", is_flag=True,
     help="""Clear the user_type field of the user.""")

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -422,7 +422,7 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
         modified = helper.api.user_modify(
             mxid, password, display_name, threepid,
             avatar_url, admin, deactivation,
-            None if user_type == 'regular' else user_type)
+            'null' if user_type == 'regular' else user_type)
         if modified is None:
             click.echo("User could not be modified.")
             raise SystemExit(1)


### PR DESCRIPTION
The user_type value is not checked (yet?) the code, although the spec allows only types `bot` and `support` (and the API will respond with `M_UNKNOWN` if an invalid value is sent). If it should be checked, let me know and i will update the PR.