### PR TITLE
Finalize PR #84 and improve --output helptext

### DIFF
--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -33,13 +33,13 @@ import re
 from synadm import api
 
 
-output_format_help = """'human' gives a tabular or list view depending on the
-fetched data. This mode needs your terminal to be quite wide! 'json' returns
-formatted json, 'minified' is minified json and displays exactly as the API
-responded. 'pprint' shows a formatted output with the help of Python's built-in
-pprint module. 'yaml' is a compromise between human- and machine-readable
-output, it doesn't need as much terminal width as 'human' does and is the
-default on fresh installations."""
+output_format_help = """The 'human' mode gives a tabular or list view depending
+on the fetched data, but often needs a lot of horizontal space to display
+correctly. 'json' returns formatted json. 'minified' is minified json, suitable
+for scripting purposes. 'pprint' shows a formatted output with the help of
+Python's built-in pprint module. 'yaml' is a compromise between human- and
+machine-readable output, it doesn't need as much terminal width as 'human' does
+and is the default on fresh installations."""
 
 
 def humanize(data):

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -358,7 +358,8 @@ def root(ctx, verbose, batch, output, config_file):
     help="""The time in seconds synadm should wait for responses from admin
     API's or Matrix API's. The default is 7 seconds. """)
 @click.option(
-    "--output", "-o", type=click.Choice(["yaml", "json", "human", "pprint"]),
+    "--output", "-o", type=click.Choice([
+        "yaml", "json", "minified", "human", "pprint"]),
     help=f"""How synadm displays data by default. {output_format_help} The
     default output format can always be overridden by using the global
     --output/-o switch (eg 'synadm -o pprint user list').""")
@@ -452,7 +453,8 @@ def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,
         "format": click.prompt(
             "Default output format",
             default=output if output else helper.config.get("format", output),
-            type=click.Choice(["yaml", "json", "jsonmini", "human", "pprint"])),
+            type=click.Choice([
+                "yaml", "json", "minified", "human", "pprint"])),
         "timeout": click.prompt(
             "Default http timeout",
             default=timeout if timeout else helper.config.get(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -33,6 +33,15 @@ import re
 from synadm import api
 
 
+output_format_help = """'human' gives a tabular or list view depending on the
+fetched data. This mode needs your terminal to be quite wide! 'json' returns
+formatted json, 'jsonmini' is minified json and displays exactly as the API
+responded. 'pprint' shows a formatted output with the help of Python's built-in
+pprint module. 'yaml' is a compromise between human- and machine-readable
+output, it doesn't need as much terminal width as 'human' does and is the
+default on fresh installations."""
+
+
 def humanize(data):
     """ Try to display data in a human-readable form:
     - Lists of dicts are displayed as tables.
@@ -62,6 +71,7 @@ class APIHelper:
     FORMATTERS = {
         "pprint": pprint.pformat,
         "json": json_pretty,
+        "jsonmini": json.dumps,
         "yaml": yaml.dump,
         "human": humanize
     }
@@ -300,10 +310,10 @@ class APIHelper:
     """)
 @click.option(
     "--output", "-o", default="",
-    type=click.Choice(["yaml", "json", "human", "pprint",
-                       "y", "j", "h", "p", ""]),
+    type=click.Choice(["yaml", "json", "jsonmini", "human", "pprint",
+                       "y", "j", "jm", "h", "p", ""]),
     show_choices=True,
-    help="""Override default output format.""")
+    help=f"Override default output format. {output_format_help}")
 @click.option(
     "--config-file", "-c", type=click.Path(),
     default="~/.config/synadm.yaml",
@@ -349,13 +359,9 @@ def root(ctx, verbose, batch, output, config_file):
     API's or Matrix API's. The default is 7 seconds. """)
 @click.option(
     "--output", "-o", type=click.Choice(["yaml", "json", "human", "pprint"]),
-    help="""How synadm displays data by default. 'human' gives a tabular or
-    list view depending on the fetched data. This mode needs your terminal to
-    be quite wide! 'json' displays exactly as the API responded. 'pprint' shows
-    nicely formatted json. 'yaml' is the currently recommended output format.
-    It doesn't need as much terminal width as 'human' does. Note that the
-    default output format can always be overridden by using global switch -o
-    (eg 'synadm -o pprint user list').""")
+    help=f"""How synadm displays data by default. {output_format_help} The
+    default output format can always be overridden by using the global
+    --output/-o switch (eg 'synadm -o pprint user list').""")
 @click.option(
     "--server-discovery", "-d", type=click.Choice(["well-known", "dns"]),
     help="""The method used for discovery of "the own homeserver name". Since
@@ -446,7 +452,7 @@ def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,
         "format": click.prompt(
             "Default output format",
             default=output if output else helper.config.get("format", output),
-            type=click.Choice(["yaml", "json", "human", "pprint"])),
+            type=click.Choice(["yaml", "json", "jsonmini", "human", "pprint"])),
         "timeout": click.prompt(
             "Default http timeout",
             default=timeout if timeout else helper.config.get(

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -63,6 +63,10 @@ def json_pretty(data):
     return json.dumps(data, indent=4)
 
 
+def json_minify(data):
+    return json.dumps(data, separator=(",", ":"))
+
+
 class APIHelper:
     """ API client enriched with CLI-level functions, used as a proxy to the
     client object.
@@ -71,7 +75,7 @@ class APIHelper:
     FORMATTERS = {
         "pprint": pprint.pformat,
         "json": json_pretty,
-        "minified": json.dumps,
+        "minified": json_minify,
         "yaml": yaml.dump,
         "human": humanize
     }

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -59,14 +59,6 @@ def humanize(data):
     return str(data)
 
 
-def json_pretty(data):
-    return json.dumps(data, indent=4)
-
-
-def json_minify(data):
-    return json.dumps(data, separator=(",", ":"))
-
-
 class APIHelper:
     """ API client enriched with CLI-level functions, used as a proxy to the
     client object.
@@ -74,8 +66,8 @@ class APIHelper:
 
     FORMATTERS = {
         "pprint": pprint.pformat,
-        "json": json_pretty,
-        "minified": json_minify,
+        "json": lambda data: json.dumps(data, indent=4),
+        "minified": lambda data: json.dumps(data, separators=(",", ":")),
         "yaml": yaml.dump,
         "human": humanize
     }

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -35,7 +35,7 @@ from synadm import api
 
 output_format_help = """'human' gives a tabular or list view depending on the
 fetched data. This mode needs your terminal to be quite wide! 'json' returns
-formatted json, 'jsonmini' is minified json and displays exactly as the API
+formatted json, 'minified' is minified json and displays exactly as the API
 responded. 'pprint' shows a formatted output with the help of Python's built-in
 pprint module. 'yaml' is a compromise between human- and machine-readable
 output, it doesn't need as much terminal width as 'human' does and is the
@@ -71,7 +71,7 @@ class APIHelper:
     FORMATTERS = {
         "pprint": pprint.pformat,
         "json": json_pretty,
-        "jsonmini": json.dumps,
+        "minified": json.dumps,
         "yaml": yaml.dump,
         "human": humanize
     }
@@ -310,8 +310,8 @@ class APIHelper:
     """)
 @click.option(
     "--output", "-o", default="",
-    type=click.Choice(["yaml", "json", "jsonmini", "human", "pprint",
-                       "y", "j", "jm", "h", "p", ""]),
+    type=click.Choice(["yaml", "json", "minified", "human", "pprint",
+                       "y", "j", "m", "h", "p", ""]),
     show_choices=True,
     help=f"Override default output format. {output_format_help}")
 @click.option(


### PR DESCRIPTION
- Keep -o json as the new default as the PR suggests.
- Add a new mode -o jsonmini that still outputs oneline-json as the original json output mode did.
- Improve handling of help text. We didn't have any description of the modes with the global --output flag. It was hidden with the config -o subcommand. It's shown in both places now.