### PR TITLE
catch missing rooms when deleting

### DIFF
--- a/synadm/cli/room.py
+++ b/synadm/cli/room.py
@@ -251,7 +251,16 @@ def delete(ctx, helper, room_id, new_room_user_id, room_name, message, block,
            no_purge):
     """ Delete and possibly purge a room.
     """
-    ctx.invoke(details, room_id=room_id)
+    room_details = helper.api.room_details(room_id)
+    if "errcode" in room_details.keys():
+        if room_details["errcode"] == "M_NOT_FOUND":
+            click.echo("Room not found.")
+            raise SystemExit(1)
+        else:
+            click.echo("Unrecognized error")
+            helper.output(room_details)
+            raise SystemExit(1)
+    helper.output(room_details)
     ctx.invoke(members, room_id=room_id)
     sure = (
         helper.batch or


### PR DESCRIPTION
it basically duplicates the details command, but now it has error
handling.
this code could probably be better if ctx.invoke returned something
useful instead of None, like info about the request or whatever.

fixes #87
References: https://github.com/JOJ0/synadm/issues/87