### PR TITLE
Adapt Click version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,7 @@ setup(
         "tabulate",
         "PyYaml",
         "click-option-group>=0.5.2",
-        "dnspython",
-        "wheel"
+        "dnspython"
     ],
     entry_points="""
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        "Click",
+        "Click>=7.0,<9.0",
         "requests",
         "tabulate",
         "PyYaml",

--- a/setup.py
+++ b/setup.py
@@ -49,12 +49,13 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        "Click>=7.0,<8.0",
+        "Click",
         "requests",
         "tabulate",
         "PyYaml",
         "click-option-group>=0.5.2",
-        "dnspython"
+        "dnspython",
+        "wheel"
     ],
     entry_points="""
         [console_scripts]


### PR DESCRIPTION
from setup.py and requirements.txt and add missing wheel package to fix pyyaml bdist_wheel error during pip install.

Fixes #97 