### PR TITLE
Rename from batch mode to non-interactive mode

### DIFF
--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -83,10 +83,10 @@ class APIHelper:
         "homeserver": "auto-retrieval"
     }
 
-    def __init__(self, config_path, verbose, batch, output_format_cli):
+    def __init__(self, config_path, verbose, no_confirm, output_format_cli):
         self.config = APIHelper.CONFIG.copy()
         self.config_path = os.path.expanduser(config_path)
-        self.batch = batch
+        self.no_confirm = no_confirm
         self.api = None
         self.init_logger(verbose)
         self.requests_debug = False
@@ -211,7 +211,7 @@ class APIHelper:
             string: hostname, FQDN or DOMAIN; or None on errors.
         """
         uri = uri if uri else self.config["base_url"]
-        echo = self.log.info if self.batch else click.echo
+        echo = self.log.info if self.no_confirm else click.echo
         if self.config["homeserver"] != "auto-retrieval":
             return self.config["homeserver"]
 
@@ -295,9 +295,9 @@ class APIHelper:
     "--verbose", "-v", count=True, default=False,
     help="Enable INFO (-v) or DEBUG (-vv) logging on console.")
 @click.option(
-    "--batch", "--yes", "--non-interactive", "--scripting",
+    "--no-confirm", "--batch", "--yes", "--non-interactive",
     default=False, is_flag=True,
-    help="""Enable batch processing mode. Use with caution! This will:
+    help="""Enable non-interactive mode. Use with caution! This will:
 
     \b
         - Disable all interactive prompts.
@@ -315,13 +315,13 @@ class APIHelper:
     default="~/.config/synadm.yaml",
     help="Configuration file path.", show_default=True)
 @click.pass_context
-def root(ctx, verbose, batch, output, config_file):
+def root(ctx, verbose, no_confirm, output, config_file):
     """ the Matrix-Synapse admin CLI
     """
-    ctx.obj = APIHelper(config_file, verbose, batch, output)
+    ctx.obj = APIHelper(config_file, verbose, no_confirm, output)
     helper_loaded = ctx.obj.load()
     if ctx.invoked_subcommand != "config" and not helper_loaded:
-        if batch:
+        if no_confirm:
             click.echo("Please setup synadm: " + sys.argv[0] + " config.")
             raise SystemExit(2)
         else:
@@ -401,11 +401,11 @@ def config_cmd(helper, user_, token, base_url, admin_path, matrix_path,
                 redacted = "REDACTED"  # Token found in config, show [REDACTED]
         return f"Synapse admin user token [{redacted}]"
 
-    if helper.batch:
+    if helper.no_confirm:
         if not all([user, token, base_url, admin_path, matrix_path,
                     output, timeout, server_discovery, homeserver]):
             click.echo(
-                "Missing config options for batch configuration!"
+                "Missing config options for non-interactive configuration!"
             )
             raise SystemExit(3)
         else:

--- a/synadm/cli/__init__.py
+++ b/synadm/cli/__init__.py
@@ -295,7 +295,7 @@ class APIHelper:
     "--verbose", "-v", count=True, default=False,
     help="Enable INFO (-v) or DEBUG (-vv) logging on console.")
 @click.option(
-    "--no-confirm", "--batch", "--yes", "--non-interactive",
+    "--no-confirm", "--batch", "--yes", "--non-interactive", "--scripting",
     default=False, is_flag=True,
     help="""Enable non-interactive mode. Use with caution! This will:
 

--- a/synadm/cli/group.py
+++ b/synadm/cli/group.py
@@ -36,7 +36,7 @@ def delete(helper, group_id):
     """ Delete a local group (community).
     """
     sure = (
-        helper.batch or
+        helper.no_confirm or
         click.prompt("Are you sure you want to delete this group? (y/N)",
                      type=bool, default=False, show_default=False)
     )

--- a/synadm/cli/history.py
+++ b/synadm/cli/history.py
@@ -82,7 +82,7 @@ def history_purge_cmd(helper, room_id, before_event_id, before_days, before,
     poll for updates on the running purge.
     """
     sure = (
-        helper.batch or
+        helper.no_confirm or
         click.prompt("Are you sure you want to purge room history? (y/N)",
                      type=bool, default=False, show_default=False)
     )
@@ -92,7 +92,7 @@ def history_purge_cmd(helper, room_id, before_event_id, before_days, before,
             delete_local
         )
 
-        if helper.batch:
+        if helper.no_confirm:
             helper.output(history_purged)
             if history_purged is None:
                 raise SystemExit(1)
@@ -118,7 +118,7 @@ def history_purge_status_cmd(helper, purge_id):
     or failed.
     """
     purge_history_status = helper.api.purge_history_status(purge_id)
-    if helper.batch:
+    if helper.no_confirm:
         if purge_history_status is None:
             raise SystemExit(1)
         helper.output(purge_history_status)

--- a/synadm/cli/matrix.py
+++ b/synadm/cli/matrix.py
@@ -48,9 +48,10 @@ def login_cmd(helper, user_id, password):
     with a display name of 'synadm matrix login command'.
     """
     if not password:
-        if helper.batch:
-            helper.log.error("Password prompt not available in batch mode. "
-                             "Use -p.")
+        if helper.no_confirm:
+            helper.log.error(
+                "Password prompt not available in non-interactive mode. "
+                "Use -p.")
             raise SystemExit(1)
         else:
             password = click.prompt("Password", hide_input=True)
@@ -58,7 +59,7 @@ def login_cmd(helper, user_id, password):
     mxid = helper.generate_mxid(user_id)
     login = helper.matrix_api.user_login(mxid, password)
 
-    if helper.batch:
+    if helper.no_confirm:
         if login is None:
             raise SystemExit(1)
         helper.output(login)
@@ -138,7 +139,7 @@ def raw_request_cmd(helper, endpoint, method, data, data_file, token, prompt):
         raw_request = helper.matrix_api.raw_request(endpoint, method, data,
                                                     token=token)
 
-    if helper.batch:
+    if helper.no_confirm:
         if raw_request is None:
             raise SystemExit(1)
         helper.output(raw_request)

--- a/synadm/cli/notice.py
+++ b/synadm/cli/notice.py
@@ -81,7 +81,7 @@ def notice_send_cmd(helper, from_file, paginate, regex, preview_length,
     """
     def confirm_prompt():
         prompt = ""
-        if helper.batch:
+        if helper.no_confirm:
             return True
         if not silent:
             prompt += "\nNote: When sending to a large amount of recipients, "

--- a/synadm/cli/room.py
+++ b/synadm/cli/room.py
@@ -263,7 +263,7 @@ def delete(ctx, helper, room_id, new_room_user_id, room_name, message, block,
     helper.output(room_details)
     ctx.invoke(members, room_id=room_id)
     sure = (
-        helper.batch or
+        helper.no_confirm or
         click.prompt("Are you sure you want to delete this room? (y/N)",
                      type=bool, default=False, show_default=False)
     )

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -116,7 +116,7 @@ def deactivate(ctx, helper, user_id, gdpr_erase):
     m_erase_or_deact = "gdpr-erase" if gdpr_erase else "deactivate"
     m_erase_or_deact_p = "gdpr-erased" if gdpr_erase else "deactivated"
     sure = (
-        helper.batch or
+        helper.no_confirm or
         click.prompt("Are you sure you want to {} this user? (y/N)"
                      .format(m_erase_or_deact),
                      type=bool, default=False, show_default=False)
@@ -394,8 +394,9 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
             click.echo(f"{key}: {value}")
 
     if password_prompt:
-        if helper.batch:
-            click.echo("Password prompt not available in batch mode. Use -P.")
+        if helper.no_confirm:
+            click.echo("Password prompt not available in non-interactive "
+                       "mode. Use -P.")
         else:
             password = click.prompt("Password", hide_input=True,
                                     confirmation_prompt=True)
@@ -404,7 +405,7 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
     else:
         password = None
     sure = (
-        helper.batch or
+        helper.no_confirm or
         click.prompt("Are you sure you want to modify user? (y/N)",
                      type=bool, default=False, show_default=False)
     )
@@ -551,7 +552,7 @@ def user_login_cmd(helper, user_id, expire_days, expire, expire_ts,
         user_login = helper.api.user_login(mxid, expire_days, expire,
                                            expire_ts)
 
-    if helper.batch:
+    if helper.no_confirm:
         if user_login is None:
             raise SystemExit(1)
         helper.output(user_login)


### PR DESCRIPTION
- Describe the "mode" in --help as "non-interactive mode"
- Add a new alias for the mode named "--no-confirm"
- Use this name as the variable name throught the project's code.
- Remove the alias "--scripting" of that mode. This might be a breaking change for users that should be discussed before merging.