### PR TITLE
bump Click version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     packages=find_packages(),
     install_requires=[
-        "Click>=7.0,<9.0",
+        "Click>=7.1,<9.0",
         "requests",
         "tabulate",
         "PyYaml",


### PR DESCRIPTION
due to 63fa8e5d7366ebc73696af8fbe1292538fb3fcf3, it does not work with Click==7.0, only Click==7.1.
I don't know why it doesn't work, but that's for another time to figure out.

i'd suggest we make a release for this?

fixes https://github.com/JOJ0/synadm/issues/106