### PR TITLE
Fix outdated docs and add "URL encoding chapter"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 - [Getting the Source \& Installing](#getting-the-source--installing)
 - [Command Design](#command-design)
   - [Implementation Examples](#implementation-examples)
-  - [Submitting data \& URL encoding](#submitting-data--url-encoding)
+  - [Sending requests \& URL encoding](#sending-requests--url-encoding)
   - [Helpers \& Utilities](#helpers--utilities)
   - [Logging](#logging)
   - [Code Documentation](#code-documentation)
@@ -152,11 +152,11 @@ and again it needs a backend method in `api.py`: https://github.com/JOJ0/synadm/
 
 ### Sending requests & URL encoding
 
-Since version 0.42 `synadm` encodes URL's in a central place - the `ApiRequest.query()` function in the `synadm.api` module.
+Since version 0.42 `synadm` encodes URL's in a central place - the `query()` method located in the [synadm.api.ApiRequest](https://synadm.readthedocs.io/en/latest/synadm.module.html#synadm.api.ApiRequest) class.
 
 Variables sent as part of the URL are required to be passed to the `query()` method **unaltered**. Do not use f-strings or str.format, let the `query()` method do the sanitizing of the URL.
 
-If we take a look at the `user password` example in above's chapter, we have:
+If we take a look at the `user_password()` example in above's chapter, we have:
 
 ```python
 self.query("post", "v1/reset_password/{user_id}", data=data, user_id=user_id)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ and again it needs a backend method in `api.py`: https://github.com/JOJ0/synadm/
 
 ### Helpers & Utilities
 
-You'll find a couple of helpers & utilities [near the top of the api module's code](https://github.com/JOJ0/synadm/blob/master/synadm/api.py#L125), right below the `query()` method, within the `ApiRequest` class. For example we already provide methods to translate unix timestamps to human readable formats and vice versa.
+You'll find a couple of helpers & utilities [near the top of the api module's code](https://github.com/JOJ0/synadm/blob/master/synadm/api.py), right below the `query()` method, within the `ApiRequest` class. For example we already provide methods to translate unix timestamps to human readable formats and vice versa.
 
 If you need to defer code to a helper function because you require reusing it or otherwise think it's a cleaner approach, put it where you need it: Either as a subfunction in your backend method in the `synadm/api` module or in the frontend function in `synadm/cli/yourcommand`. If you think you've wrote a function that is very generic and might be useful to other `synadm/api` methods as well, put it next to the helpers in the `ApiRequest` class and tell us about it in a PR-comment.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ And another example, this time using a POST based API endpoint. It implements co
 and again it needs a backend method in `api.py`: https://github.com/JOJ0/synadm/blob/68749391d6a291d2fac229214f59924189c775ac/synadm/api.py#L511-L529
 
 
-### Submitting data & URL encoding
+### Sending requests & URL encoding
 
 Since version 0.42 `synadm` encodes URL's in a central place - the `ApiRequest.query()` function in the `synadm.api` module.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ and again it needs a backend method in `api.py`: https://github.com/JOJ0/synadm/
 
 ### Sending requests & URL encoding
 
-Since commit [6874939](https://github.com/JOJ0/synadm/commit/68749391d6a291d2fac229214f59924189c775ac) (released in v0.42) `synadm` encodes URL's in a central place - the `query()` method located in the [synadm.api.ApiRequest](https://synadm.readthedocs.io/en/latest/synadm.module.html#synadm.api.ApiRequest) class.
+Since commit [6874939](https://github.com/JOJ0/synadm/commit/68749391d6a291d2fac229214f59924189c775ac) (released in v0.41.2) `synadm` encodes URL's in a central place - the `query()` method located in the [synadm.api.ApiRequest](https://synadm.readthedocs.io/en/latest/synadm.module.html#synadm.api.ApiRequest) class.
 
 Variables sent as part of the URL are required to be passed to the `query()` method **unaltered**. Do not use f-strings or str.format, let the `query()` method do the sanitizing of the URL.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,16 +138,15 @@ _Note: If you are not familiar with Python code, don't let yourself get distract
 
 ### Implementation Examples
 
-Have a look at this method: https://github.com/JOJ0/synadm/blob/107d34b38de71d6d21d78141e78a1b19d3dd5379/synadm/cli/user.py#L185
+Have a look at this method: https://github.com/JOJ0/synadm/blob/68749391d6a291d2fac229214f59924189c775ac/synadm/cli/user.py#L358-L369
 
-and this one: https://github.com/JOJ0/synadm/blob/107d34b38de71d6d21d78141e78a1b19d3dd5379/synadm/api.py#L80
+and this one: https://github.com/JOJ0/synadm/blob/68749391d6a291d2fac229214f59924189c775ac/synadm/api.py#L531-L545
 
 That's all it needs to implement command `synadm user details <user_id>`.
 
-And another example, this time using a POST based API endpoint. It implements command `synadm user password <user_id>`. This is the CLI-level method: https://github.com/JOJ0/synadm/blob/0af918fdeee40bc1d3df7b734a46e76bb31148b9/synadm/cli/user.py#L114
+And another example, this time using a POST based API endpoint. It implements command `synadm user password <user_id>`. This is the CLI-level method: https://github.com/JOJ0/synadm/blob/68749391d6a291d2fac229214f59924189c775ac/synadm/cli/user.py#L276-L301
 
-and again it needs a backend method in `api.py`:
-https://github.com/JOJ0/synadm/blob/107d34b38de71d6d21d78141e78a1b19d3dd5379/synadm/api.py#L72
+and again it needs a backend method in `api.py`: https://github.com/JOJ0/synadm/blob/68749391d6a291d2fac229214f59924189c775ac/synadm/api.py#L511-L529
 
 
 ### Helpers & Utilities

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ and again it needs a backend method in `api.py`: https://github.com/JOJ0/synadm/
 
 ### Sending requests & URL encoding
 
-Since version 0.42 `synadm` encodes URL's in a central place - the `query()` method located in the [synadm.api.ApiRequest](https://synadm.readthedocs.io/en/latest/synadm.module.html#synadm.api.ApiRequest) class.
+Since commit [6874939](https://github.com/JOJ0/synadm/commit/68749391d6a291d2fac229214f59924189c775ac) (released in v0.42) `synadm` encodes URL's in a central place - the `query()` method located in the [synadm.api.ApiRequest](https://synadm.readthedocs.io/en/latest/synadm.module.html#synadm.api.ApiRequest) class.
 
 Variables sent as part of the URL are required to be passed to the `query()` method **unaltered**. Do not use f-strings or str.format, let the `query()` method do the sanitizing of the URL.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ self.query("post", "v1/reset_password/{user_id}", data=data, user_id=user_id)
 ```
 
 - `data` is the dictionary we'd like to send in the body of the request.
-- The 'user_id` should be passed as part of the URL. We don't do any formatting or URL-encoding on our end, we hand it over as keyword argument to the `query() method` and use a replacement field surrounded by curly braces to mark its position in the URL.
+- The `user_id` should be passed as part of the URL. We don't do any formatting or URL-encoding on our end, we hand it over as keyword argument to the `query() method` and use a "replacement field" surrounded by curly braces to mark its position in the URL.
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
 - [Getting the Source \& Installing](#getting-the-source--installing)
 - [Command Design](#command-design)
   - [Implementation Examples](#implementation-examples)
+  - [Submitting data \& URL encoding](#submitting-data--url-encoding)
   - [Helpers \& Utilities](#helpers--utilities)
   - [Logging](#logging)
   - [Code Documentation](#code-documentation)
@@ -147,6 +148,23 @@ That's all it needs to implement command `synadm user details <user_id>`.
 And another example, this time using a POST based API endpoint. It implements command `synadm user password <user_id>`. This is the CLI-level method: https://github.com/JOJ0/synadm/blob/68749391d6a291d2fac229214f59924189c775ac/synadm/cli/user.py#L276-L301
 
 and again it needs a backend method in `api.py`: https://github.com/JOJ0/synadm/blob/68749391d6a291d2fac229214f59924189c775ac/synadm/api.py#L511-L529
+
+
+### Submitting data & URL encoding
+
+Since version 0.42 `synadm` encodes URL's in a central place - the `ApiRequest.query()` function in the `synadm.api` module.
+
+Variables sent as part of the URL are required to be passed to the `query()` method **unaltered**. Do not use f-strings or str.format, let the `query()` method do the sanitizing of the URL.
+
+If we take a look at the `user password` example in above's chapter, we have:
+
+```
+self.query("post", "v1/reset_password/{user_id}", data=data, user_id=user_id)
+```
+
+- `data` is the dictionary we'd like to send in the body of the request.
+- The 'user_id` should be passed as part of the URL. We don't do any formatting or URL-encoding on our end, we hand it over as keyword argument to the `query() method` and use a replacement field surrounded by curly braces to mark its position in the URL.
+
 
 
 ### Helpers & Utilities

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,12 +158,12 @@ Variables sent as part of the URL are required to be passed to the `query()` met
 
 If we take a look at the `user password` example in above's chapter, we have:
 
-```
+```python
 self.query("post", "v1/reset_password/{user_id}", data=data, user_id=user_id)
 ```
 
-- `data` is the dictionary we'd like to send in the body of the request.
-- The `user_id` should be passed as part of the URL. We don't do any formatting or URL-encoding on our end, we hand it over as keyword argument to the `query() method` and use a "replacement field" surrounded by curly braces to mark its position in the URL.
+- The `data` argument is passed as the request body and expects a Python dictionary.
+- The `{user_id}` part of the URL will be replaced by the keyword argument `user_id`. The value of the keyword argument `user_id` will also be URL encoded to ensure [special cases](https://github.com/JOJ0/synadm/issues/96) don't break things.
 
 
 


### PR DESCRIPTION
This fixes links to code snippets in CONTRIBUTING.md chapter "Implementation Examples" and adds a chapter about the newly introduced way of formatting strings in the `query()` method of `ApiRequest`.