### PR TITLE
Fix regtok delete and others

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -1148,8 +1148,8 @@ class SynapseAdmin(ApiRequest):
                 an exception occured. See Synapse admin API docs for details.
 
         """
-        result = self.query("get", "v1/registration_tokens/{token}",
-                            token=token)
+        result = self.query("get", "v1/registration_tokens/{t}",
+                            t=token)
 
         # Change expiry_time to a human readable format if requested
         if (
@@ -1244,8 +1244,8 @@ class SynapseAdmin(ApiRequest):
             self.log.debug(f"Received --expire-at: {expire_at}")
             data["expiry_time"] = self._timestamp_from_datetime(expire_at)
 
-        return self.query("put", "v1/registration_tokens/{token}", data=data,
-                          token=token)
+        return self.query("put", "v1/registration_tokens/{t}", data=data,
+                          t=token)
 
     def regtok_delete(self, token):
         """ Delete a registration token


### PR DESCRIPTION
Fixes: #110

> Issue: `query` function accepts `token` as an arg, it doesn't go into `**kwargs` so `KeyError`.
> 
> May need to review other things that use conflicting keywords.

https://github.com/JOJ0/synadm/issues/110#issuecomment-1590032158

This PR fixes the conflicting keywords issue. I haven't found anymore of the same issue (I checked).