### PR TITLE
Migrate readthedocs "config via UI" to .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: ./sphinx_requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,5 @@ sphinx:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
+  - requirements: ./requirements.txt
   - requirements: ./sphinx_requirements.txt


### PR DESCRIPTION
dev branch seems to build fine now.  I tested by deleting all the configurations from rtd-UI (Admin - Advanced Settings - Default Settings)

master/latest is failing right now but that is expected. It should build fine again after mergen this PR, which I will do without waiting for a review. This is just an informative PR to keep our merge history tidy.