### PR TITLE
Use requests.request instead of getting attrs to make requests

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -131,8 +131,8 @@ class ApiRequest:
             override_verify = verify
 
         try:
-            resp = getattr(requests, method)(
-                url, headers=self.headers, timeout=self.timeout,
+            resp = requests.request(
+                method, url, headers=self.headers, timeout=self.timeout,
                 params=params, json=data, verify=override_verify
             )
             if not resp.ok:


### PR DESCRIPTION
Getting attributes is kind of hacky and not really that readable (or easily understood), so requests.request was used because it accepts HTTP methods.

(yeah I left the commit hanging around for a good few days)