### PR TITLE
admin filter for user listing

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -415,7 +415,7 @@ class SynapseAdmin(ApiRequest):
         self.user = user
 
     def user_list(self, _from, _limit, _guests, _deactivated,
-                  _name, _user_id):
+                  _name, _user_id, _admin):
         """List and search users
 
         Args:
@@ -426,11 +426,13 @@ class SynapseAdmin(ApiRequest):
             _name (string): user name localpart to search for, see Synapse
                 admin API docs for details
             _user_id (string): fully qualified Matrix user ID to search for
+            _admin (bool or None): whether to filter for admins. a None
+                does not filter.
 
         Returns:
             string: JSON string containing the found users
         """
-        return self.query("get", "v2/users", params={
+        params = {
             "from": _from,
             "limit": _limit,
             "guests": (str(_guests).lower() if isinstance(_guests, bool)
@@ -438,7 +440,10 @@ class SynapseAdmin(ApiRequest):
             "deactivated": "true" if _deactivated else None,
             "name": _name,
             "user_id": _user_id
-        })
+        }
+        if _admin is not None:
+            params["admins"] = str(_admin).lower()
+        return self.query("get", "v2/users", params=params)
 
     def user_list_paginate(self, _limit, _guests, _deactivated,
                            _name, _user_id, _from="0"):

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -53,6 +53,10 @@ def user():
 @click.option(
     "--deactivated", "-d", is_flag=True, default=False,
     help="Also show deactivated/erased users", show_default=True)
+@click.option(
+    "--admins/--non-admins", "-a/-A", default=None,
+    help="""Whether to filter for admins, or non-admins. If not specified,
+    no admin filter is applied.""")
 @optgroup.group(
     "Search options",
     cls=MutuallyExclusiveOptionGroup,
@@ -67,12 +71,13 @@ def user():
     help="""Search users by ID - filters to only return users with Matrix IDs
     (@user:server) that contain this value""")
 @click.pass_obj
-def list_user_cmd(helper, from_, limit, guests, deactivated, name, user_id):
+def list_user_cmd(helper, from_, limit, guests, deactivated, name, user_id,
+                  admins):
     """ List users, search for users.
     """
     mxid = helper.generate_mxid(user_id)
     users = helper.api.user_list(from_, limit, guests, deactivated, name,
-                                 mxid)
+                                 mxid, admins)
     if users is None:
         click.echo("Users could not be fetched.")
         raise SystemExit(1)


### PR DESCRIPTION
the admin filter is a tri-state, meaning it can filter for admins, filter for non-admins, and not filter at all.

fixes #122

~~NOTE: It is a draft PR because I am looking for a cleaner solution of "the user said no based on this flag here" rather than the [current manual solution](https://github.com/JOJ0/synadm/pull/123/files#diff-a41082dbe9c56e01f08c3854a53edc1f26bae33f9de966cd4ed8e228fc2bf621R84-R88) of checking. If that's not possible, then this is pretty much complete.~~ found a cleaner solution