### PR TITLE
Rewriting the user modify command

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -605,6 +605,7 @@ class SynapseAdmin(ApiRequest):
 
         Threepid should be passed as a tuple in a tuple
         """
+        # TODO: deprecate
         data = {}
         if password:
             data.update({"password": password})

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -505,6 +505,11 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
         click.echo("Abort.")
 
 
+# for these placeholders, function similarly to the modify command, but in
+# it's own command.
+# TODO: find 3pid modify command
+
+
 @user.command()
 @click.argument("user_id", type=str)
 @click.argument("user_type", type=str)


### PR DESCRIPTION
Currently a placeholder. Only about the structure of commands (and maybe the parameters) until agreed.

Initial idea: https://github.com/JOJ0/synadm/issues/100#issuecomment-1704264088

Resolves #100

[Placeholder/existing commands checklist](https://github.com/JOJ0/synadm/pull/126#issuecomment-1725298794)

(Commits history will 100% get rewritten after the code is finished)

---

Progress checklist:
- [x] Placeholders (see [checklist](https://github.com/JOJ0/synadm/pull/126#issuecomment-1725298794) and https://github.com/JOJ0/synadm/pull/126#issuecomment-1733108725)
- [x] Agreed placeholders ([agreed](https://github.com/JOJ0/synadm/pull/126#issuecomment-1742535566))
- [x] Implementation
- [ ] TODOs (deprecating, check `synadm user reactivate` with `--batch`)
- [ ] Testing everything new (including deprecation warning)
- [ ] Make README up to date with these changes
