### PR TITLE
User modify command threepid handling fixes

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -603,7 +603,8 @@ class SynapseAdmin(ApiRequest):
                     avatar_url, admin, deactivation, user_type, lock):
         """ Create or update information about a given user
 
-        Threepid should be passed as a tuple in a tuple
+        The threepid argument must be passed as a tuple in a tuple (which is
+        what we usually get from a Click multi-arg option)
         """
         data = {}
         if password:

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -612,7 +612,7 @@ class SynapseAdmin(ApiRequest):
             data.update({"displayname": display_name})
         if threepid:
             data.update({"threepids": [
-                {"medium": k, "address": i} for k, i in dict(threepid).items()
+                {"medium": m, "address": a} for m, a in threepid
             ]})
         if avatar_url:
             data.update({"avatar_url": avatar_url})

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -612,9 +612,12 @@ class SynapseAdmin(ApiRequest):
         if display_name:
             data.update({"displayname": display_name})
         if threepid:
-            data.update({"threepids": [
-                {"medium": m, "address": a} for m, a in threepid
-            ]})
+            if threepid == (('', ''),):  # empty strings clear all threepids
+                data.update({"threepids": []})
+            else:
+                data.update({"threepids": [
+                    {"medium": m, "address": a} for m, a in threepid
+                ]})
         if avatar_url:
             data.update({"avatar_url": avatar_url})
         if admin is not None:

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -394,14 +394,15 @@ class UserModifyOptionGroup(RequiredAnyOptionGroup):
     help="Set display name. defaults to the value of user_id")
 @optgroup.option(
     "--threepid", "-t", type=str, multiple=True, nargs=2,
-    help="""Add a third-party identifier (email address or phone number).
-    Threepids are used for several things: For use when logging in, as an
-    alternative to the user id; in the case of email, as an alternative contact
-    to help with account recovery; as well as to receive notifications of
-    missed messages. This option requires two arguments: `medium value` (eg.
-    `--threepid email <user@example.org>`). To configure multiple entries for a
-    user, this option can be passed multiple times. To clear _all_ threepids,
-    pass it _once_ while setting two empty strings: '' ''.""")
+    help="""Set a third-party identifier (email address or phone number). Pass
+    two arguments: `medium value` (eg. `--threepid email <user@example.org>`).
+    This option can be passed multiple times, which allows setting multiple
+    entries for a user. When modifying existing users, all threepids are
+    replaced by what's passed in all given `--threepid` options. Threepids are
+    used for several things: For use when logging in, as an alternative to the
+    user id; in the case of email, as an alternative contact to help with
+    account recovery, as well as to receive notifications of missed
+    messages.""")
 @optgroup.option(
     "--avatar-url", "-v", type=str,
     help="""Set avatar URL. Must be a MXC URI

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -394,14 +394,14 @@ class UserModifyOptionGroup(RequiredAnyOptionGroup):
     help="Set display name. defaults to the value of user_id")
 @optgroup.option(
     "--threepid", "-t", type=str, multiple=True, nargs=2,
-    help="""Add a third-party identifier. This can be an email address or a
-    phone number. Threepids are used for several things: For use when
-    logging in, as an alternative to the user id. In the case of email, as
-    an alternative contact to help with account recovery, as well as
-    to receive notifications of missed messages. Format: medium
-    value (eg. --threepid email <user@example.org>). This option can also
-    be stated multiple times, i.e. a user can have multiple threepids
-    configured.""")
+    help="""Add a third-party identifier (email address or phone number).
+    Threepids are used for several things: For use when logging in, as an
+    alternative to the user id; in the case of email, as an alternative contact
+    to help with account recovery; as well as to receive notifications of
+    missed messages. This option requires two arguments: `medium value` (eg.
+    `--threepid email <user@example.org>`). To configure multiple entries for a
+    user, this option can be passed multiple times. To clear _all_ threepids,
+    pass it _once_ while setting two empty strings: '' ''.""")
 @optgroup.option(
     "--avatar-url", "-v", type=str,
     help="""Set avatar URL. Must be a MXC URI

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -456,14 +456,13 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
         if key in ["user_id", "password", "password_prompt"]:  # skip these
             continue
         if key == "threepid":
-            if value != ():
-                for t_key, t_val in value:
-                    click.echo(f"{key}: {t_key} {t_val}")
-                    if t_key not in ["email", "msisdn"]:
-                        helper.log.warning(
-                            f"{t_key} is probably not a supported medium "
-                            "type. Threepid medium types according to the "
-                            "current matrix spec are: email, msisdn.")
+            for t_key, t_val in value:
+                click.echo(f"{key}: {t_key} {t_val}")
+                if t_key not in ["email", "msisdn"]:
+                    helper.log.warning(
+                        f"{t_key} is probably not a supported medium "
+                        "type. Threepid medium types according to the "
+                        "current matrix spec are: email, msisdn.")
         elif key == "user_type" and value == 'regular':
             click.echo("user_type: null")
         elif value not in [None, {}, []]:  # only show non-empty (aka changed)

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -491,7 +491,7 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
         password = None
     sure = (
         helper.no_confirm or
-        click.prompt("Are you sure you want to modify user? (y/N)",
+        click.prompt("Are you sure you want to modify/create user? (y/N)",
                      type=bool, default=False, show_default=False)
     )
     if sure:
@@ -506,12 +506,12 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
             'null' if user_type == 'regular' else user_type, lock
         )
         if modified is None:
-            click.echo("User could not be modified.")
+            click.echo("User could not be modified/created.")
             raise SystemExit(1)
         if helper.output_format == "human":
             if modified != {}:
                 helper.output(modified)
-                click.echo("User successfully modified.")
+                click.echo("User successfully modified/created.")
             else:
                 click.echo("Synapse returned: {}".format(modified))
         else:

--- a/synadm/cli/user.py
+++ b/synadm/cli/user.py
@@ -456,6 +456,9 @@ def modify(ctx, helper, user_id, password, password_prompt, display_name,
         if key in ["user_id", "password", "password_prompt"]:  # skip these
             continue
         if key == "threepid":
+            if value == (('', ''),):
+                click.echo("threepid: All entries will be cleared!")
+                continue
             for t_key, t_val in value:
                 click.echo(f"{key}: {t_key} {t_val}")
                 if t_key not in ["email", "msisdn"]:


### PR DESCRIPTION
Fixes #135

Improve the `--threepid`option of the `user modify` command.

- Support removing **all** threepids by passing `--clear-threepids`
  Note: If a user has the idea/follows the logic that resetting according to the API docs (https://matrix-org.github.io/synapse/latest/admin_api/user_admin_api.html#create-or-modify-account) should also work by setting it to "empty", ie. `--threepid '' ''`, that will also work, but it is not documented in `--help`!
- Extend and clarify `--help` for this option.
- Fix an issue where passing multiple `--threepid` options, sets only the last of the argument pairs the user had provided on the cli (ignoring all others).