### PR TITLE
Allow to run the module without installing it

### DIFF
--- a/synadm/__main__.py
+++ b/synadm/__main__.py
@@ -1,3 +1,30 @@
+# -*- coding: utf-8 -*-
+# synadm
+# Copyright (C) 2023 Nicolas Peugnet
+#
+# synadm is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# synadm is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Alternative entry point for running synadm
+
+synadm is typically installed via pip, utilizing setuptools-configured entry
+points for accessibility as `synadm`.
+
+This file allows execution without formal installation using
+`python -m synadm`, which proves useful, for instance, in Debian GNU/Linux
+packaging.
+"""
+
 from synadm.cli import root
 
 root()

--- a/synadm/__main__.py
+++ b/synadm/__main__.py
@@ -1,0 +1,3 @@
+from synadm.cli import root
+
+root()


### PR DESCRIPTION
As explained previously, I want to add the click generated bash completion script to the Debian package. Here is the change I sent to the Debian maintainer of synadm : https://salsa.debian.org/matrix-team/synadm/-/merge_requests/1

The only way I found to make it work was to add a "main" file that allows to run synadm without installing it. As I thought it could be useful outside the Debian package, here is the forwarded patch, that allows to run synadm directly with `python -m synadm`.

I am no expert in Python so this might not be the ideal way to do it.