### PR TITLE
Exit synadm early on fatal errors, refactor & fix `query()`

### DIFF
--- a/synadm/api.py
+++ b/synadm/api.py
@@ -31,10 +31,10 @@ https://matrix.org/docs/spec/#matrix-apis.
 import datetime
 import json
 import re
-from typing import Optional, Union, Dict, List, Any
+import traceback
 import urllib.parse
 from http.client import HTTPConnection
-import traceback
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -52,7 +52,7 @@ def log_fatal_exit(error, logger, message=None):
     if message is None:
         message = "synadm exited due to a fatal error."
 
-    # split by new lines that's already included
+    # format_exception() returns a list of strings. join it into a single string again. 
     logger.info("".join(traceback.format_exception(error)))
 
     logger.fatal(

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -36,7 +36,7 @@ import urllib.parse
 from http.client import HTTPConnection
 
 import requests
-from requests.exceptions import InvalidURL, MissingSchema, ConnectionError
+from requests.exceptions import ConnectionError
 
 
 def log_fatal_exit(error, logger, message=None):
@@ -161,10 +161,6 @@ class ApiRequest:
                                  f"{resp.status_code}")
             return resp.json()
         except ConnectionError as error:
-            log_fatal_exit(error, self.log)
-        except InvalidURL as error:
-            log_fatal_exit(error, self.log)
-        except MissingSchema as error:
             log_fatal_exit(error, self.log, "Connection error. Please check "
                            "that Synapse can be reached.")
         except Exception as error:

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -30,10 +30,21 @@ https://matrix.org/docs/spec/#matrix-apis.
 
 import requests
 from http.client import HTTPConnection
+from requests.exceptions import InvalidURL, MissingSchema
 import datetime
 import json
 import urllib.parse
 import re
+
+
+def log_fatal_exit(error, logger):
+    """Log a fatal error and exit synadm."""
+    logger.fatal(
+        "%s: %s.\nsynadm exited due to a fatal error.",
+        type(error).__name__,
+        error,
+    )
+    raise SystemExit(1) from error
 
 
 class ApiRequest:
@@ -139,6 +150,12 @@ class ApiRequest:
                 self.log.warning(f"{host_descr} returned status code "
                                  f"{resp.status_code}")
             return resp.json()
+        except ConnectionError as error:
+            log_fatal_exit(error, self.log)
+        except InvalidURL as error:
+            log_fatal_exit(error, self.log)
+        except MissingSchema as error:
+            log_fatal_exit(error, self.log)
         except Exception as error:
             self.log.error("%s while querying %s: %s",
                            type(error).__name__, host_descr, error)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -41,7 +41,14 @@ from requests.exceptions import ConnectionError
 
 
 def log_fatal_exit(error, logger, message=None):
-    """Log a fatal error and exit synadm."""
+    """Log a fatal error and exit synadm.
+
+    Args:
+        error: A Python exception.
+        logger: A Python logger, with info and fatal methods
+        message: Message to use instead of "synadm exited due to a fatal
+            error."
+    """
     if message is None:
         message = "synadm exited due to a fatal error."
 

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -53,7 +53,11 @@ def log_fatal_exit(error, logger, message=None):
 
     # format_exception() returns a list of strings (with new lines). join it
     # into a single string again for readability.
-    logger.info("".join(traceback.format_exception(error)))
+    #
+    # error specified multiple times to ensure it works with python 3.9 and
+    # versions after that which accept things differently
+    logger.info("".join(traceback.format_exception(error, error,
+                                                   error.__traceback__)))
 
     logger.fatal(
         "%s: %s.\n\n%s",

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -103,19 +103,19 @@ class ApiRequest:
         Handles requests methods, logging and exceptions, and URL encoding.
 
         Args:
-            urlpart (string): The path to the API endpoint, excluding
-                self.base_url and self.path (the part after
-                proto://fqdn:port/path). It will be passed to Python's
-                str.format, so the string should not be already formatted
-                (as f-strings or with str.format) as to sanitize the URL.
-            params (dict, optional): URL parameters (?param1&param2).  Defaults
-                to None.
-            data (dict, optional): Request body used in POST, PUT, DELETE
-                requests.  Defaults to None.
-            base_url_override (bool): The default setting of self.base_url set
+            method: The http method to use (get, post, put, ...)
+            urlpart: The path to the API endpoint, excluding self.base_url and
+                self.path (the part after proto://fqdn:port/path). It will be
+                passed to Python's str.format, so the string should not be
+                already formatted (as f-strings or with str.format) as to
+                sanitize the URL.
+            params: URL parameters (?param1&param2)..
+            data: Request body used in POST, PUT, DELETE requests.
+            token: An optional token overriding the configured one.
+            base_url_override: The default setting of self.base_url set
                 on initialization can be overwritten using this argument.
-            verify(bool): Mandatory SSL verification is turned on by default
-                and can be turned off using this method.
+            verify: Mandatory SSL verification is on by default and can be
+                turned off using this method.
             *args: Arguments that will be URL encoded and passed to Python's
                 str.format.
             **kwargs: Keyword arguments that will be URL encoded (only the

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -118,9 +118,7 @@ class ApiRequest:
                 logged and None is returned.
         """
         args = [urllib.parse.quote(arg, safe="") for arg in args]
-        kwargs = dict(kwargs)
-        for i in kwargs.keys():
-            kwargs[i] = urllib.parse.quote(kwargs[i], safe="")
+        kwargs = {k: urllib.parse.quote(v, safe="") for k, v in kwargs.items()}
         urlpart = urlpart.format(*args, **kwargs)
 
         if base_url_override:

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -31,6 +31,7 @@ https://matrix.org/docs/spec/#matrix-apis.
 import datetime
 import json
 import re
+from typing import Optional, Union, Dict, List, Any
 import urllib.parse
 from http.client import HTTPConnection
 
@@ -85,8 +86,18 @@ class ApiRequest:
             HTTPConnection.debuglevel = 1
         self.verify = verify
 
-    def query(self, method, urlpart, *args, params=None, data=None, token=None,
-              base_url_override=None, verify=None, **kwargs):
+    def query(
+        self,
+        method,
+        urlpart,
+        *args,
+        params=None,
+        data=None,
+        token=None,
+        base_url_override=None,
+        verify=None,
+        **kwargs,
+    ) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]], None]]:
         """Generic wrapper around requests methods.
 
         Handles requests methods, logging and exceptions, and URL encoding.

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -49,7 +49,7 @@ def log_fatal_exit(error, logger, message=None):
     logger.info("".join(traceback.format_exception(error)))
 
     logger.fatal(
-        "%s: %s.\n%s",
+        "%s: %s.\n\n%s",
         type(error).__name__,
         error, message
     )

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -85,8 +85,8 @@ class ApiRequest:
             HTTPConnection.debuglevel = 1
         self.verify = verify
 
-    def query(self, method, urlpart, params=None, data=None, token=None,
-              base_url_override=None, verify=None, *args, **kwargs):
+    def query(self, method, urlpart, *args, params=None, data=None, token=None,
+              base_url_override=None, verify=None, **kwargs):
         """Generic wrapper around requests methods.
 
         Handles requests methods, logging and exceptions, and URL encoding.

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -117,10 +117,8 @@ class ApiRequest:
                 JSON strings. On exceptions the error type and description are
                 logged and None is returned.
         """
-        args = list(args)
+        args = [urllib.parse.quote(arg, safe="") for arg in args]
         kwargs = dict(kwargs)
-        for i in range(len(args)):
-            args[i] = urllib.parse.quote(args[i], safe="")
         for i in kwargs.keys():
             kwargs[i] = urllib.parse.quote(kwargs[i], safe="")
         urlpart = urlpart.format(*args, **kwargs)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -34,6 +34,7 @@ import re
 from typing import Optional, Union, Dict, List, Any
 import urllib.parse
 from http.client import HTTPConnection
+import traceback
 
 import requests
 from requests.exceptions import ConnectionError
@@ -43,6 +44,10 @@ def log_fatal_exit(error, logger, message=None):
     """Log a fatal error and exit synadm."""
     if message is None:
         message = "synadm exited due to a fatal error."
+
+    # split by new lines that's already included
+    logger.info("".join(traceback.format_exception(error)))
+
     logger.fatal(
         "%s: %s.\n%s",
         type(error).__name__,

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -111,7 +111,7 @@ class ApiRequest:
         base_url_override: Optional[bool] = False,
         verify: Optional[bool] = True,
         **kwargs: Dict[str, Any],
-    ) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]], None]]:
+Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]
         """Generic wrapper around requests methods.
 
         Handles requests methods, logging and exceptions, and URL encoding.

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -37,7 +37,6 @@ from http.client import HTTPConnection
 import traceback
 
 import requests
-from requests.exceptions import ConnectionError
 
 
 def log_fatal_exit(error, logger, message=None):
@@ -172,7 +171,7 @@ class ApiRequest:
                 self.log.warning(f"{host_descr} returned status code "
                                  f"{resp.status_code}")
             return resp.json()
-        except ConnectionError as error:
+        except requests.exceptions.ConnectionError as error:
             log_fatal_exit(error, self.log, "Connection error. Please check "
                            "that Synapse can be reached.")
         except Exception as error:

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -36,7 +36,7 @@ import urllib.parse
 from http.client import HTTPConnection
 
 import requests
-from requests.exceptions import InvalidURL, MissingSchema
+from requests.exceptions import InvalidURL, MissingSchema, ConnectionError
 
 
 def log_fatal_exit(error, logger):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -28,13 +28,14 @@ documentation of the Synapse Admin APIs and the Matrix spec at
 https://matrix.org/docs/spec/#matrix-apis.
 """
 
-import requests
-from http.client import HTTPConnection
-from requests.exceptions import InvalidURL, MissingSchema
 import datetime
 import json
-import urllib.parse
 import re
+import urllib.parse
+from http.client import HTTPConnection
+
+import requests
+from requests.exceptions import InvalidURL, MissingSchema
 
 
 def log_fatal_exit(error, logger):

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -39,12 +39,14 @@ import requests
 from requests.exceptions import InvalidURL, MissingSchema, ConnectionError
 
 
-def log_fatal_exit(error, logger):
+def log_fatal_exit(error, logger, message=None):
     """Log a fatal error and exit synadm."""
+    if message is None:
+        message = "synadm exited due to a fatal error."
     logger.fatal(
-        "%s: %s.\nsynadm exited due to a fatal error.",
+        "%s: %s.\n%s",
         type(error).__name__,
-        error,
+        error, message
     )
     raise SystemExit(1) from error
 

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -137,11 +137,10 @@ class ApiRequest:
                 values) and passed to Python's str.format.
 
         Returns:
-            string or None: Usually a JSON string containing
-                the response of the API; responses that are not 200(OK) (usally
-                error messages returned by the API) will also be returned as
-                JSON strings. On exceptions the error type and description are
-                logged and None is returned.
+            A dict, list or None. If it's a dict or list, it is a JSON
+            decoded response. Whether it is a dict or a list depends on what
+            the server responds with. It returns a None if any exceptions
+            are encountered.
         """
         args = [urllib.parse.quote(arg, safe="") for arg in args]
         kwargs = {k: urllib.parse.quote(v, safe="") for k, v in kwargs.items()}

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -88,15 +88,15 @@ class ApiRequest:
 
     def query(
         self,
-        method,
-        urlpart,
-        *args,
-        params=None,
-        data=None,
-        token=None,
-        base_url_override=None,
-        verify=None,
-        **kwargs,
+        method: str,
+        urlpart: str,
+        *args: Any,
+        params: Optional[Dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        token: Optional[str] = None,
+        base_url_override: Optional[bool] = False,
+        verify: Optional[bool] = True,
+        **kwargs: Dict[str, Any],
     ) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]], None]]:
         """Generic wrapper around requests methods.
 

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -52,7 +52,8 @@ def log_fatal_exit(error, logger, message=None):
     if message is None:
         message = "synadm exited due to a fatal error."
 
-    # format_exception() returns a list of strings. join it into a single string again. 
+    # format_exception() returns a list of strings (with new lines). join it
+    # into a single string again for readability.
     logger.info("".join(traceback.format_exception(error)))
 
     logger.fatal(

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -165,7 +165,8 @@ class ApiRequest:
         except InvalidURL as error:
             log_fatal_exit(error, self.log)
         except MissingSchema as error:
-            log_fatal_exit(error, self.log)
+            log_fatal_exit(error, self.log, "Connection error. Please check "
+                           "that Synapse can be reached.")
         except Exception as error:
             self.log.error("%s while querying %s: %s",
                            type(error).__name__, host_descr, error)

--- a/synadm/api.py
+++ b/synadm/api.py
@@ -112,7 +112,7 @@ class ApiRequest:
         base_url_override: Optional[bool] = False,
         verify: Optional[bool] = True,
         **kwargs: Dict[str, Any],
-Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]
+    ) -> Optional[Union[Dict[str, Any], List[Dict[str, Any]]]]:
         """Generic wrapper around requests methods.
 
         Handles requests methods, logging and exceptions, and URL encoding.


### PR DESCRIPTION
Addresses general error handling issues discussed in: #164

- What actually is a fatal error where it does not make sense to continue? I picked a few already. There might be more. Please suggest!
- Is it really a good idea to define `log_fatal_exit()` directly in this module as a regular function? Should it live inside `ApiRequest`? Or move it to a "utils-like" place? Will we use it outside this module too?
- Some refactoring along the way
- Add type hints (we can discuss if this is the right place and time....)
- Fix docstring
   - arguments done
   - return value: FIXME, isn't this entirely wrong? `resp.json()` returns lists or dicts. Or what does `json string` mean in this context? It's no string in reality....

